### PR TITLE
Simplify contract flow

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
     {
       "files": "*.sol",
       "options": {
-        "printWidth": 180,
+        "printWidth": 100,
         "tabWidth": 4,
         "useTabs": false,
         "singleQuote": false,

--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -11,6 +11,7 @@ error SignerMustBeServerError();
 error SignatureExpiredError();
 
 error BoutInWrongStateError(uint boutId, BoutState state);
+error BoutExpiredError(uint boutId, uint expiryTime);
 error PotMismatchError(uint boutId, uint fighterAPot, uint fighterBPot, uint totalPot);
 error MinimumBetAmountError(uint boutId, address bettor, uint amount);
 error InvalidBetTargetError(uint boutId, address bettor, uint8 br);

--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -13,6 +13,7 @@ error SignatureExpiredError();
 error BoutInWrongStateError(uint boutId, BoutState state);
 error BoutExpiredError(uint boutId, uint expiryTime);
 error PotMismatchError(uint boutId, uint fighterAPot, uint fighterBPot, uint totalPot);
+error RevealValuesError(uint boutId);
 error MinimumBetAmountError(uint boutId, address bettor, uint amount);
 error InvalidBetTargetError(uint boutId, address bettor, uint8 br);
 error InvalidWinnerError(uint boutId, BoutFighter winner);

--- a/src/Errors.sol
+++ b/src/Errors.sol
@@ -10,9 +10,10 @@ error CallerMustBeServerError();
 error SignerMustBeServerError();
 error SignatureExpiredError();
 
-error BoutInWrongStateError(uint boutNum, BoutState state);
-error MinimumBetAmountError(uint boutNum, address supporter, uint amount);
-error InvalidBetTargetError(uint boutNum, address supporter, uint8 br);
-error InvalidWinnerError(uint boutNum, BoutFighter winner);
+error BoutInWrongStateError(uint boutId, BoutState state);
+error PotMismatchError(uint boutId, uint fighterAPot, uint fighterBPot, uint totalPot);
+error MinimumBetAmountError(uint boutId, address bettor, uint amount);
+error InvalidBetTargetError(uint boutId, address bettor, uint8 br);
+error InvalidWinnerError(uint boutId, BoutFighter winner);
 
 error TokenBalanceInsufficient(uint256 userBalance, uint256 amount);

--- a/src/InitDiamond.sol
+++ b/src/InitDiamond.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.17;
 
 import { AppStorage, LibAppStorage } from "src/Objects.sol";
-import { LibConstants, LibTokenIds } from "./libs/LibConstants.sol";
+import { LibConstants } from "./libs/LibConstants.sol";
+import { LibTokenIds } from "./libs/LibToken.sol";
 import { LibDiamond } from "lib/diamond-2-hardhat/contracts/libraries/LibDiamond.sol";
 import { LibEip712 } from "src/libs/LibEip712.sol";
 import { IDiamondCut } from "lib/diamond-2-hardhat/contracts/interfaces/IDiamondCut.sol";

--- a/src/MemeToken.sol
+++ b/src/MemeToken.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.17 <0.9;
 
 import { IERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { ITokenImplFacet } from "./interfaces/ITokenImplFacet.sol";
-import { LibTokenIds } from "./libs/LibConstants.sol";
+import { LibTokenIds } from "./libs/LibToken.sol";
 
 contract MemeToken is IERC20 {
     ITokenImplFacet public impl;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -9,7 +9,7 @@ enum BoutState {
 }
 
 enum BoutFighter {
-    Uninitialized,
+    Invalid,
     FighterA,
     FighterB
 }

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -52,7 +52,7 @@ struct BoutNonMappingInfo {
     uint numRevealedBets;
     uint totalPot;
     uint revealTime;
-    uint endTime;
+    uint endTime;\
     BoutState state;
     BoutFighter winner;
     BoutFighter loser;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -52,7 +52,7 @@ struct BoutNonMappingInfo {
     uint numRevealedBets;
     uint totalPot;
     uint revealTime;
-    uint endTime;\
+    uint endTime;
     BoutState state;
     BoutFighter winner;
     BoutFighter loser;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -23,7 +23,7 @@ enum MemeBuySizeDollars {
 }
 
 struct Bout {
-    uint numSupporters;
+    uint numBettors;
     uint totalPot;
     uint createTime;
     uint endTime;
@@ -48,7 +48,7 @@ struct Bout {
  * This is used to return Bout data from external calls.
  */
 struct BoutNonMappingInfo {
-    uint numSupporters;
+    uint numBettors;
     uint totalPot;
     uint createTime;
     uint expiryTime;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -24,7 +24,6 @@ enum MemeBuySizeDollars {
 
 struct Bout {
     uint numSupporters;
-    uint numRevealedBets;
     uint totalPot;
     uint createTime;
     uint endTime;
@@ -49,7 +48,6 @@ struct Bout {
  */
 struct BoutNonMappingInfo {
     uint numSupporters;
-    uint numRevealedBets;
     uint totalPot;
     uint createTime;
     uint endTime;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -5,7 +5,7 @@ enum BoutState {
     Uninitialized,
     Created,
     Ended,
-    Cancelled
+    Expired
 }
 
 enum BoutFighter {
@@ -27,6 +27,7 @@ struct Bout {
     uint totalPot;
     uint createTime;
     uint endTime;
+    uint expiryTime;
     BoutState state;
     BoutFighter winner;
     BoutFighter loser;
@@ -50,6 +51,7 @@ struct BoutNonMappingInfo {
     uint numSupporters;
     uint totalPot;
     uint createTime;
+    uint expiryTime;
     uint endTime;
     BoutState state;
     BoutFighter winner;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -26,7 +26,7 @@ struct Bout {
     uint numSupporters;
     uint numRevealedBets;
     uint totalPot;
-    uint revealTime;
+    uint createTime;
     uint endTime;
     BoutState state;
     BoutFighter winner;
@@ -51,7 +51,7 @@ struct BoutNonMappingInfo {
     uint numSupporters;
     uint numRevealedBets;
     uint totalPot;
-    uint revealTime;
+    uint createTime;
     uint endTime;
     BoutState state;
     BoutFighter winner;

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -67,6 +67,30 @@ struct EIP712 {
     bytes32 TYPE_HASH;
 }
 
+// Linked list node to keep track of bouts
+struct BoutListNode {
+    // id of bout
+    uint boutId;
+    // id of previous node in list
+    uint prev;
+    // id of next node in list
+    uint next;
+}
+
+// Linked list to keep track of bouts
+struct BoutList {
+    // node id => node item
+    mapping(uint => BoutListNode) nodes;
+    // id of first node in list
+    uint head;
+    // id of last node in list
+    uint tail;
+    // length of list
+    uint len;
+    // id of next node to be added
+    uint nextId;
+}
+
 struct AppStorage {
     bool diamondInitialized;
     ///
@@ -107,8 +131,8 @@ struct AppStorage {
 
     // wallet => no. of bouts supported
     mapping(address => uint) userTotalBoutsBetOn;
-    // wallet => no. of bouts where winnings claimed
-    mapping(address => uint) userTotalBoutsWinningsClaimed;
+    // wallet => linked list of bouts where winnings still need to be claimed
+    mapping(address => BoutList) userBoutsWinningsToClaimList;
     // wallet => list of bouts supported
     mapping(address => mapping(uint => uint)) userBoutsBetOnByIndex;
     // tokenId => is this an item being sold by DegenFighter?

--- a/src/Objects.sol
+++ b/src/Objects.sol
@@ -2,14 +2,14 @@
 pragma solidity >=0.8.17 <0.9;
 
 enum BoutState {
-    Unknown,
+    Uninitialized,
     Created,
-    BetsRevealed,
-    Ended
+    Ended,
+    Cancelled
 }
 
 enum BoutFighter {
-    Unknown,
+    Uninitialized,
     FighterA,
     FighterB
 }
@@ -23,7 +23,6 @@ enum MemeBuySizeDollars {
 }
 
 struct Bout {
-    uint id;
     uint numSupporters;
     uint numRevealedBets;
     uint totalPot;
@@ -32,9 +31,10 @@ struct Bout {
     BoutState state;
     BoutFighter winner;
     BoutFighter loser;
-    mapping(uint => address) supporters;
+    uint8[] revealValues; // the 'r' values packed into 2 bits each
+    mapping(uint => address) bettors;
+    mapping(address => uint) bettorIndexes;
     mapping(address => uint8) hiddenBets;
-    mapping(address => BoutFighter) revealedBets;
     mapping(address => uint) betAmounts;
     mapping(address => bool) winningsClaimed;
     mapping(BoutFighter => uint) fighterIds;
@@ -48,7 +48,6 @@ struct Bout {
  * This is used to return Bout data from external calls.
  */
 struct BoutNonMappingInfo {
-    uint id;
     uint numSupporters;
     uint numRevealedBets;
     uint totalPot;
@@ -57,6 +56,7 @@ struct BoutNonMappingInfo {
     BoutState state;
     BoutFighter winner;
     BoutFighter loser;
+    uint8[] revealValues; // the 'r' values packed into 2 bits each
 }
 
 // from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/EIP712.sol
@@ -99,18 +99,20 @@ struct AppStorage {
     uint totalBouts;
     // no. of bouts finished
     uint endedBouts;
-    // bout => details
+    // bout id => bout details
     mapping(uint => Bout) bouts;
+    // bout index => bout id
+    mapping(uint => uint) boutIdByIndex;
     ///
-    /// Fight supporters
+    /// Fight bettors
     ///
 
     // wallet => no. of bouts supported
-    mapping(address => uint) userBoutsSupported;
+    mapping(address => uint) userTotalBoutsBetOn;
     // wallet => no. of bouts where winnings claimed
-    mapping(address => uint) userBoutsWinningsClaimed;
+    mapping(address => uint) userTotalBoutsWinningsClaimed;
     // wallet => list of bouts supported
-    mapping(address => mapping(uint => uint)) userBoutsSupportedByIndex;
+    mapping(address => mapping(uint => uint)) userBoutsBetOnByIndex;
     // tokenId => is this an item being sold by DegenFighter?
     mapping(uint256 => bool) itemForSale;
     // tokenId => cost of item in MEMEs

--- a/src/facets/BettingFacet.sol
+++ b/src/facets/BettingFacet.sol
@@ -7,215 +7,43 @@ import "../Errors.sol";
 import { AppStorage, LibAppStorage, Bout, BoutState, BoutFighter } from "../Objects.sol";
 import { IBettingFacet } from "../interfaces/IBettingFacet.sol";
 import { FacetBase } from "../FacetBase.sol";
-import { LibConstants, LibTokenIds } from "../libs/LibConstants.sol";
+import { LibConstants } from "../libs/LibConstants.sol";
 import { LibEip712 } from "../libs/LibEip712.sol";
-import { LibToken } from "../libs/LibToken.sol";
+import { LibToken, LibTokenIds } from "../libs/LibToken.sol";
+import { LibBetting } from "../libs/LibBetting.sol";
 
 contract BettingFacet is FacetBase, IBettingFacet {
     using SafeMath for uint;
 
     constructor() FacetBase() {}
 
-    function createBout(uint fighterA, uint fighterB) external isServer {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        s.totalBouts++;
-        Bout storage bout = s.bouts[s.totalBouts];
-        bout.id = s.totalBouts;
-        bout.state = BoutState.Created;
-        bout.winner = BoutFighter.Unknown;
-        bout.loser = BoutFighter.Unknown;
-        bout.fighterIds[BoutFighter.FighterA] = fighterA;
-        bout.fighterIds[BoutFighter.FighterB] = fighterB;
-
-        emit BoutCreated(bout.id);
+    function calculateBetSignature(address server, address bettor, uint256 boutId, uint8 br, uint256 amount, uint256 deadline) public returns (bytes32) {
+        return LibBetting.calculateBetSignature(server, bettor, boutId, br, amount, deadline);
     }
 
-    function calculateBetSignature(address server, address supporter, uint256 boutNum, uint8 br, uint256 amount, uint256 deadline) public returns (bytes32) {
-        return
-            LibEip712.hashTypedDataV4(
-                keccak256(abi.encode(keccak256("calculateBetSignature(address,address,uint256,uint8,uint256,uint256)"), server, supporter, boutNum, br, amount, deadline))
-            );
+    function bet(uint boutId, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external {
+        address bettor = _msgSender();
+
+        LibBetting.bet(boutId, bettor, br, amount, deadline, sigV, sigR, sigS);
+
+        emit BetPlaced(boutId, bettor);
     }
 
-    function bet(uint boutNum, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external {
-        AppStorage storage s = LibAppStorage.diamondStorage();
+    function endBout(uint boutId, uint fighterAId, uint fighterBId, uint fighterAPot, uint fighterBPot, BoutFighter winner, uint8[] calldata revealValues) external isServer {
+        LibBetting.endBout(boutId, fighterAId, fighterBId, fighterAPot, fighterBPot, winner, revealValues);
 
-        Bout storage bout = s.bouts[boutNum];
-
-        if (bout.state != BoutState.Created) {
-            revert BoutInWrongStateError(boutNum, bout.state);
-        }
-
-        address server = s.addresses[LibConstants.SERVER_ADDRESS];
-        address supporter = _msgSender();
-
-        // recover signer
-        bytes32 digest = calculateBetSignature(server, supporter, boutNum, br, amount, deadline);
-        address signer = LibEip712.recover(digest, sigV, sigR, sigS);
-
-        // final checks
-        if (signer != server) {
-            revert SignerMustBeServerError();
-        }
-        if (block.timestamp >= deadline) {
-            revert SignatureExpiredError();
-        }
-        if (amount < LibConstants.MIN_BET_AMOUNT) {
-            revert MinimumBetAmountError(boutNum, supporter, amount);
-        }
-        if (br < 1 || br > 3) {
-            revert InvalidBetTargetError(boutNum, supporter, br);
-        }
-
-        // replace old bet?
-        if (bout.hiddenBets[supporter] != 0) {
-            // refund old bet
-            bout.totalPot = bout.totalPot.sub(bout.betAmounts[supporter]);
-            LibToken.transfer(LibTokenIds.TOKEN_MEME, address(this), supporter, bout.betAmounts[supporter]);
-        }
-        // new bet?
-        else {
-            // add to supporter list
-            bout.numSupporters += 1;
-            bout.supporters[bout.numSupporters] = supporter;
-            // update user data
-            s.userBoutsSupported[supporter] += 1;
-            s.userBoutsSupportedByIndex[supporter][s.userBoutsSupported[supporter]] = boutNum;
-        }
-
-        // add to pot
-        bout.totalPot = bout.totalPot.add(amount);
-        bout.betAmounts[supporter] = amount;
-        bout.hiddenBets[supporter] = br;
-
-        // transfer bet
-        LibToken.transfer(LibTokenIds.TOKEN_MEME, supporter, address(this), amount);
-
-        emit BetPlaced(boutNum, supporter);
+        emit BoutEnded(boutId);
     }
 
-    function revealBets(uint boutNum, uint numValues, uint8[] calldata rPacked) external isServer {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-
-        Bout storage bout = s.bouts[boutNum];
-
-        if (bout.state != BoutState.Created && bout.state != BoutState.BetsRevealed) {
-            revert BoutInWrongStateError(boutNum, bout.state);
-        }
-
-        uint count;
-
-        // do reveal
-        for (uint i = bout.numRevealedBets; i < bout.numSupporters && count < numValues; i++) {
-            uint rPackedIndex = (i - bout.numRevealedBets) >> 2;
-            uint8 r = (rPacked[rPackedIndex] >> ((3 - (i % 4)) * 2)) & 3;
-            address supporter = bout.supporters[i + 1];
-            uint8 rawBet;
-            if (bout.hiddenBets[supporter] >= r) {
-                rawBet = bout.hiddenBets[supporter] - r;
-            }
-            // default to 0 if invalid
-            if (rawBet != 0 && rawBet != 1) {
-                rawBet = 0;
-            }
-
-            // update supporter bet data & fighter pot
-            bout.revealedBets[supporter] = (rawBet == 0 ? BoutFighter.FighterA : BoutFighter.FighterB);
-            BoutFighter fighter = bout.revealedBets[supporter];
-            bout.fighterPots[fighter] = bout.fighterPots[fighter].add(bout.betAmounts[supporter]);
-            bout.fighterPotBalances[fighter] = bout.fighterPotBalances[fighter].add(bout.betAmounts[supporter]);
-
-            // count
-            bout.numRevealedBets++;
-            count++;
-        }
-
-        bout.state = BoutState.BetsRevealed;
-        bout.revealTime = block.timestamp;
-
-        emit BetsRevealed(boutNum, count);
-    }
-
-    function endBout(uint boutNum, BoutFighter winner) external isServer {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-
-        Bout storage bout = s.bouts[boutNum];
-
-        if (bout.state != BoutState.BetsRevealed) {
-            revert BoutInWrongStateError(boutNum, bout.state);
-        }
-
-        if (winner != BoutFighter.FighterA && winner != BoutFighter.FighterB) {
-            revert InvalidWinnerError(boutNum, winner);
-        }
-
-        bout.state = BoutState.Ended;
-        bout.endTime = block.timestamp;
-        bout.winner = winner;
-        bout.loser = (winner == BoutFighter.FighterA ? BoutFighter.FighterB : BoutFighter.FighterA);
-        s.endedBouts++;
-
-        emit BoutEnded(boutNum);
-    }
-
-    function getBoutWinnings(uint boutNum, address wallet) public view returns (uint total, uint selfAmount, uint won) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-
-        Bout storage bout = s.bouts[boutNum];
-
-        if (bout.winner == bout.revealedBets[wallet]) {
-            // how much of losing pot do we get?
-            uint ratio = (bout.betAmounts[wallet] * 1000 ether) / bout.fighterPots[bout.winner];
-            won = (ratio * bout.fighterPots[bout.loser]) / 1000 ether;
-            // how much did we put in?
-            selfAmount = bout.betAmounts[wallet];
-            // total winnings
-            total = selfAmount + won;
-        }
+    function getBoutWinnings(uint boutId, address wallet) external view returns (uint total, uint selfAmount, uint won) {
+        return LibBetting.getBoutWinnings(boutId, wallet);
     }
 
     function getClaimableWinnings(address wallet) external view returns (uint) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-
-        uint winnings = 0;
-
-        for (uint i = s.userBoutsWinningsClaimed[wallet] + 1; i <= s.userBoutsSupported[wallet]; i++) {
-            uint boutNum = s.userBoutsSupportedByIndex[wallet][i];
-            (uint total, , ) = getBoutWinnings(boutNum, wallet);
-            winnings = winnings.add(total);
-        }
-
-        return winnings;
+        return LibBetting.getClaimableWinnings(wallet);
     }
 
     function claimWinnings(address wallet, uint maxBoutsToClaim) external {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-
-        uint totalWinnings = 0;
-        uint count = 0;
-
-        for (uint i = s.userBoutsWinningsClaimed[wallet] + 1; i <= s.userBoutsSupported[wallet] && count < maxBoutsToClaim; i++) {
-            uint boutNum = s.userBoutsSupportedByIndex[wallet][i];
-
-            (uint total, uint selfAmount, uint won) = getBoutWinnings(boutNum, wallet);
-
-            Bout storage bout = s.bouts[boutNum];
-
-            bout.winningsClaimed[wallet] = true;
-
-            if (total > 0) {
-                bout.fighterPotBalances[bout.winner] = bout.fighterPotBalances[bout.winner].sub(selfAmount);
-                bout.fighterPotBalances[bout.loser] = bout.fighterPotBalances[bout.loser].sub(won);
-                totalWinnings = totalWinnings.add(total);
-            }
-
-            s.userBoutsWinningsClaimed[wallet]++;
-            count++;
-        }
-
-        // transfer winnings
-        if (totalWinnings > 0) {
-            LibToken.transfer(LibTokenIds.TOKEN_MEME, address(this), wallet, totalWinnings);
-        }
+        LibBetting.claimWinnings(wallet, maxBoutsToClaim);
     }
 }

--- a/src/facets/BettingFacet.sol
+++ b/src/facets/BettingFacet.sol
@@ -17,11 +17,26 @@ contract BettingFacet is FacetBase, IBettingFacet {
 
     constructor() FacetBase() {}
 
-    function calculateBetSignature(address server, address bettor, uint256 boutId, uint8 br, uint256 amount, uint256 deadline) public returns (bytes32) {
+    function calculateBetSignature(
+        address server,
+        address bettor,
+        uint256 boutId,
+        uint8 br,
+        uint256 amount,
+        uint256 deadline
+    ) public returns (bytes32) {
         return LibBetting.calculateBetSignature(server, bettor, boutId, br, amount, deadline);
     }
 
-    function bet(uint boutId, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external {
+    function bet(
+        uint boutId,
+        uint8 br,
+        uint amount,
+        uint deadline,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         address bettor = _msgSender();
@@ -46,14 +61,33 @@ contract BettingFacet is FacetBase, IBettingFacet {
         emit BetPlaced(boutId, bettor);
     }
 
-    function endBout(uint boutId, uint fighterAId, uint fighterBId, uint fighterAPot, uint fighterBPot, BoutFighter winner, uint8[] calldata revealValues) external isServer {
-        LibBetting.endBout(boutId, fighterAId, fighterBId, fighterAPot, fighterBPot, winner, revealValues);
+    function endBout(
+        uint boutId,
+        uint fighterAId,
+        uint fighterBId,
+        uint fighterAPot,
+        uint fighterBPot,
+        BoutFighter winner,
+        uint8[] calldata revealValues
+    ) external isServer {
+        LibBetting.endBout(
+            boutId,
+            fighterAId,
+            fighterBId,
+            fighterAPot,
+            fighterBPot,
+            winner,
+            revealValues
+        );
 
         emit BoutEnded(boutId);
     }
 
-    function getBoutWinnings(uint boutId, address wallet) external view returns (uint total, uint selfAmount, uint won) {
-        return LibBetting.getBoutWinnings(boutId, wallet);
+    function getBoutClaimableAmounts(
+        uint boutId,
+        address wallet
+    ) external view returns (uint totalToClaim, uint selfBetAmount, uint loserPotAmountToClaim) {
+        return LibBetting.getBoutClaimableAmounts(boutId, wallet);
     }
 
     function getClaimableWinnings(address wallet) external view returns (uint) {

--- a/src/facets/BettingFacet.sol
+++ b/src/facets/BettingFacet.sol
@@ -17,17 +17,6 @@ contract BettingFacet is FacetBase, IBettingFacet {
 
     constructor() FacetBase() {}
 
-    function calculateBetSignature(
-        address server,
-        address bettor,
-        uint256 boutId,
-        uint8 br,
-        uint256 amount,
-        uint256 deadline
-    ) public returns (bytes32) {
-        return LibBetting.calculateBetSignature(server, bettor, boutId, br, amount, deadline);
-    }
-
     function bet(
         uint boutId,
         uint8 br,
@@ -96,5 +85,16 @@ contract BettingFacet is FacetBase, IBettingFacet {
 
     function claimWinnings(address wallet, uint maxBoutsToClaim) external {
         LibBetting.claimWinnings(wallet, maxBoutsToClaim);
+    }
+
+    function calculateBetSignature(
+        address server,
+        address bettor,
+        uint256 boutId,
+        uint8 br,
+        uint256 amount,
+        uint256 deadline
+    ) public returns (bytes32) {
+        return LibBetting.calculateBetSignature(server, bettor, boutId, br, amount, deadline);
     }
 }

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -42,7 +42,17 @@ contract InfoFacet is FacetBase, IInfoFacet {
     function getBoutNonMappingInfo(uint boutId) external view returns (BoutNonMappingInfo memory) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         Bout storage bout = s.bouts[boutId];
-        return BoutNonMappingInfo(bout.numSupporters, bout.numRevealedBets, bout.totalPot, bout.createTime, bout.endTime, bout.state, bout.winner, bout.loser, bout.revealValues);
+        return
+            BoutNonMappingInfo(
+                bout.numSupporters,
+                bout.totalPot,
+                bout.createTime,
+                bout.endTime,
+                bout.state,
+                bout.winner,
+                bout.loser,
+                bout.revealValues
+            );
     }
 
     function getBoutSupporter(uint boutId, uint bettorNum) external view returns (address) {

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -42,7 +42,7 @@ contract InfoFacet is FacetBase, IInfoFacet {
     function getBoutNonMappingInfo(uint boutId) external view returns (BoutNonMappingInfo memory) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         Bout storage bout = s.bouts[boutId];
-        return BoutNonMappingInfo(bout.numSupporters, bout.numRevealedBets, bout.totalPot, bout.revealTime, bout.endTime, bout.state, bout.winner, bout.loser, bout.revealValues);
+        return BoutNonMappingInfo(bout.numSupporters, bout.numRevealedBets, bout.totalPot, bout.createTime, bout.endTime, bout.state, bout.winner, bout.loser, bout.revealValues);
     }
 
     function getBoutSupporter(uint boutId, uint bettorNum) external view returns (address) {

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -44,7 +44,7 @@ contract InfoFacet is FacetBase, IInfoFacet {
         Bout storage bout = s.bouts[boutId];
         return
             BoutNonMappingInfo({
-                numSupporters: bout.numSupporters,
+                numBettors: bout.numBettors,
                 totalPot: bout.totalPot,
                 createTime: bout.createTime,
                 expiryTime: bout.expiryTime,

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.17 <0.9;
 import { FacetBase } from "../FacetBase.sol";
 import { AppStorage, LibAppStorage, Bout, BoutFighter, BoutNonMappingInfo } from "../Objects.sol";
 import { IInfoFacet } from "../interfaces/IInfoFacet.sol";
+import { LibBetting } from "../libs/LibBetting.sol";
 
 contract InfoFacet is FacetBase, IInfoFacet {
     constructor() FacetBase() {}
@@ -13,6 +14,11 @@ contract InfoFacet is FacetBase, IInfoFacet {
         return s.totalBouts;
     }
 
+    function getBoutIdByIndex(uint boutIndex) external view returns (uint) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        return s.boutIdByIndex[boutIndex];
+    }
+
     function getEndedBouts() external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.endedBouts;
@@ -20,71 +26,70 @@ contract InfoFacet is FacetBase, IInfoFacet {
 
     function getUserBoutsWinningsClaimed(address wallet) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        return s.userBoutsWinningsClaimed[wallet];
+        return s.userTotalBoutsWinningsClaimed[wallet];
     }
 
     function getUserBoutsSupported(address wallet) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        return s.userBoutsSupported[wallet];
+        return s.userTotalBoutsBetOn[wallet];
     }
 
     function getUserSupportedBoutAtIndex(address wallet, uint index) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        return s.userBoutsSupportedByIndex[wallet][index];
+        return s.userBoutsBetOnByIndex[wallet][index];
     }
 
-    function getBoutNonMappingInfo(uint boutNum) external view returns (BoutNonMappingInfo memory) {
+    function getBoutNonMappingInfo(uint boutId) external view returns (BoutNonMappingInfo memory) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
-
-        return BoutNonMappingInfo(boutNum, bout.numSupporters, bout.numRevealedBets, bout.totalPot, bout.revealTime, bout.endTime, bout.state, bout.winner, bout.loser);
+        Bout storage bout = s.bouts[boutId];
+        return BoutNonMappingInfo(bout.numSupporters, bout.numRevealedBets, bout.totalPot, bout.revealTime, bout.endTime, bout.state, bout.winner, bout.loser, bout.revealValues);
     }
 
-    function getBoutSupporter(uint boutNum, uint supporterNum) external view returns (address) {
+    function getBoutSupporter(uint boutId, uint bettorNum) external view returns (address) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
-        return bout.supporters[supporterNum];
+        Bout storage bout = s.bouts[boutId];
+        return bout.bettors[bettorNum];
     }
 
-    function getBoutHiddenBet(uint boutNum, address supporter) external view returns (uint8) {
+    function getBoutHiddenBet(uint boutId, address bettor) external view returns (uint8) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
-        return bout.hiddenBets[supporter];
+        Bout storage bout = s.bouts[boutId];
+        return bout.hiddenBets[bettor];
     }
 
-    function getBoutRevealedBet(uint boutNum, address supporter) external view returns (BoutFighter) {
+    function getBoutRevealedBet(uint boutId, address bettor) external view returns (BoutFighter) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
-        return bout.revealedBets[supporter];
+        Bout storage bout = s.bouts[boutId];
+        return LibBetting.getRevealedBet(bout, bettor);
     }
 
-    function getBoutBetAmount(uint boutNum, address supporter) external view returns (uint) {
+    function getBoutBetAmount(uint boutId, address bettor) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
-        return bout.betAmounts[supporter];
+        Bout storage bout = s.bouts[boutId];
+        return bout.betAmounts[bettor];
     }
 
-    function getBoutWinningsClaimed(uint boutNum, address supporter) external view returns (bool) {
+    function getBoutWinningsClaimed(uint boutId, address bettor) external view returns (bool) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
-        return bout.winningsClaimed[supporter];
+        Bout storage bout = s.bouts[boutId];
+        return bout.winningsClaimed[bettor];
     }
 
-    function getBoutFighterId(uint boutNum, BoutFighter p) external view returns (uint) {
+    function getBoutFighterId(uint boutId, BoutFighter p) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
+        Bout storage bout = s.bouts[boutId];
         return bout.fighterIds[p];
     }
 
-    function getBoutFighterPot(uint boutNum, BoutFighter p) external view returns (uint) {
+    function getBoutFighterPot(uint boutId, BoutFighter p) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
+        Bout storage bout = s.bouts[boutId];
         return bout.fighterPots[p];
     }
 
-    function getBoutFighterPotBalance(uint boutNum, BoutFighter p) external view returns (uint) {
+    function getBoutFighterPotBalance(uint boutId, BoutFighter p) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        Bout storage bout = s.bouts[boutNum];
+        Bout storage bout = s.bouts[boutId];
         return bout.fighterPotBalances[p];
     }
 }

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -26,7 +26,7 @@ contract InfoFacet is FacetBase, IInfoFacet {
 
     function getUserBoutsWinningsClaimed(address wallet) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        return s.userTotalBoutsWinningsClaimed[wallet];
+        return s.userTotalBoutsBetOn[wallet] - s.userBoutsWinningsToClaimList[wallet].len;
     }
 
     function getUserBoutsSupported(address wallet) external view returns (uint) {

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -29,12 +29,12 @@ contract InfoFacet is FacetBase, IInfoFacet {
         return s.userTotalBoutsBetOn[wallet] - s.userBoutsWinningsToClaimList[wallet].len;
     }
 
-    function getUserBoutsSupported(address wallet) external view returns (uint) {
+    function getUserBoutsBetOn(address wallet) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.userTotalBoutsBetOn[wallet];
     }
 
-    function getUserSupportedBoutAtIndex(address wallet, uint index) external view returns (uint) {
+    function getUserBoutBetOnAtIndex(address wallet, uint index) external view returns (uint) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.userBoutsBetOnByIndex[wallet][index];
     }

--- a/src/facets/InfoFacet.sol
+++ b/src/facets/InfoFacet.sol
@@ -43,16 +43,17 @@ contract InfoFacet is FacetBase, IInfoFacet {
         AppStorage storage s = LibAppStorage.diamondStorage();
         Bout storage bout = s.bouts[boutId];
         return
-            BoutNonMappingInfo(
-                bout.numSupporters,
-                bout.totalPot,
-                bout.createTime,
-                bout.endTime,
-                bout.state,
-                bout.winner,
-                bout.loser,
-                bout.revealValues
-            );
+            BoutNonMappingInfo({
+                numSupporters: bout.numSupporters,
+                totalPot: bout.totalPot,
+                createTime: bout.createTime,
+                expiryTime: bout.expiryTime,
+                endTime: bout.endTime,
+                state: bout.state,
+                winner: bout.winner,
+                loser: bout.loser,
+                revealValues: bout.revealValues
+            });
     }
 
     function getBoutSupporter(uint boutId, uint bettorNum) external view returns (address) {

--- a/src/facets/ItemsMarketFacet.sol
+++ b/src/facets/ItemsMarketFacet.sol
@@ -6,7 +6,8 @@ import { NotAllowedError } from "../Errors.sol";
 import { AppStorage, LibAppStorage, MemeBuySizeDollars } from "../Objects.sol";
 import { ITokenImplFacet } from "../interfaces/ITokenImplFacet.sol";
 import { IERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import { LibConstants, LibTokenIds } from "../libs/LibConstants.sol";
+import { LibConstants } from "../libs/LibConstants.sol";
+import { LibTokenIds } from "../libs/LibToken.sol";
 
 import { LibToken } from "src/libs/LibToken.sol";
 import { LibUniswapV3Twap } from "src/libs/LibUniswapV3Twap.sol";

--- a/src/facets/MemeMarketFacet.sol
+++ b/src/facets/MemeMarketFacet.sol
@@ -8,8 +8,8 @@ import { NotAllowedError } from "../Errors.sol";
 import { AppStorage, LibAppStorage, MemeBuySizeDollars } from "../Objects.sol";
 import { ITokenImplFacet } from "../interfaces/ITokenImplFacet.sol";
 import { IERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import { LibConstants, LibTokenIds } from "../libs/LibConstants.sol";
-import { LibToken } from "src/libs/LibToken.sol";
+import { LibConstants } from "../libs/LibConstants.sol";
+import { LibToken, LibTokenIds } from "src/libs/LibToken.sol";
 import { LibUniswapV3Twap } from "src/libs/LibUniswapV3Twap.sol";
 
 contract MemeMarketFacet is FacetBase {

--- a/src/interfaces/IBettingFacet.sol
+++ b/src/interfaces/IBettingFacet.sol
@@ -7,15 +7,6 @@ interface IBettingFacet {
     event BetPlaced(uint boutId, address bettor);
     event BoutEnded(uint boutId);
 
-    function calculateBetSignature(
-        address server,
-        address bettor,
-        uint boutId,
-        uint8 br,
-        uint amount,
-        uint deadline
-    ) external returns (bytes32);
-
     function bet(
         uint boutId,
         uint8 br,
@@ -44,4 +35,13 @@ interface IBettingFacet {
     function getClaimableWinnings(address wallet) external view returns (uint);
 
     function claimWinnings(address wallet, uint maxBoutsToClaim) external;
+
+    function calculateBetSignature(
+        address server,
+        address bettor,
+        uint boutId,
+        uint8 br,
+        uint amount,
+        uint deadline
+    ) external returns (bytes32);
 }

--- a/src/interfaces/IBettingFacet.sol
+++ b/src/interfaces/IBettingFacet.sol
@@ -4,22 +4,16 @@ pragma solidity >=0.8.17 <0.9;
 import { Bout, BoutFighter } from "../Objects.sol";
 
 interface IBettingFacet {
-    event BoutCreated(uint boutNum);
-    event BetPlaced(uint boutNum, address supporter);
-    event BetsRevealed(uint boutNum, uint numBetsRevealed);
-    event BoutEnded(uint boutNum);
+    event BetPlaced(uint boutId, address bettor);
+    event BoutEnded(uint boutId);
 
-    function createBout(uint fighterA, uint fighterB) external;
+    function calculateBetSignature(address server, address bettor, uint boutId, uint8 br, uint amount, uint deadline) external returns (bytes32);
 
-    function calculateBetSignature(address server, address supporter, uint boutNum, uint8 br, uint amount, uint deadline) external returns (bytes32);
+    function bet(uint boutId, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external;
 
-    function bet(uint boutNum, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external;
+    function endBout(uint boutId, uint fighterAId, uint fighterBId, uint fighterAPot, uint fighterBPot, BoutFighter winner, uint8[] calldata revealValues) external;
 
-    function revealBets(uint boutNum, uint numValues, uint8[] calldata rPacked) external;
-
-    function endBout(uint boutNum, BoutFighter winner) external;
-
-    function getBoutWinnings(uint boutNum, address wallet) external view returns (uint total, uint selfAmount, uint won);
+    function getBoutWinnings(uint boutId, address wallet) external view returns (uint total, uint selfAmount, uint won);
 
     function getClaimableWinnings(address wallet) external view returns (uint);
 

--- a/src/interfaces/IBettingFacet.sol
+++ b/src/interfaces/IBettingFacet.sol
@@ -7,13 +7,39 @@ interface IBettingFacet {
     event BetPlaced(uint boutId, address bettor);
     event BoutEnded(uint boutId);
 
-    function calculateBetSignature(address server, address bettor, uint boutId, uint8 br, uint amount, uint deadline) external returns (bytes32);
+    function calculateBetSignature(
+        address server,
+        address bettor,
+        uint boutId,
+        uint8 br,
+        uint amount,
+        uint deadline
+    ) external returns (bytes32);
 
-    function bet(uint boutId, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external;
+    function bet(
+        uint boutId,
+        uint8 br,
+        uint amount,
+        uint deadline,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external;
 
-    function endBout(uint boutId, uint fighterAId, uint fighterBId, uint fighterAPot, uint fighterBPot, BoutFighter winner, uint8[] calldata revealValues) external;
+    function endBout(
+        uint boutId,
+        uint fighterAId,
+        uint fighterBId,
+        uint fighterAPot,
+        uint fighterBPot,
+        BoutFighter winner,
+        uint8[] calldata revealValues
+    ) external;
 
-    function getBoutWinnings(uint boutId, address wallet) external view returns (uint total, uint selfAmount, uint won);
+    function getBoutClaimableAmounts(
+        uint boutId,
+        address wallet
+    ) external view returns (uint totalToClaim, uint selfBetAmount, uint loserPotAmountToClaim);
 
     function getClaimableWinnings(address wallet) external view returns (uint);
 

--- a/src/interfaces/IInfoFacet.sol
+++ b/src/interfaces/IInfoFacet.sol
@@ -6,6 +6,8 @@ import { BoutNonMappingInfo, BoutFighter } from "../Objects.sol";
 interface IInfoFacet {
     function getTotalBouts() external view returns (uint);
 
+    function getBoutIdByIndex(uint boutIndex) external view returns (uint);
+
     function getEndedBouts() external view returns (uint);
 
     function getUserBoutsWinningsClaimed(address wallet) external view returns (uint);
@@ -14,21 +16,21 @@ interface IInfoFacet {
 
     function getUserSupportedBoutAtIndex(address wallet, uint index) external view returns (uint);
 
-    function getBoutNonMappingInfo(uint boutNum) external view returns (BoutNonMappingInfo memory);
+    function getBoutNonMappingInfo(uint boutId) external view returns (BoutNonMappingInfo memory);
 
-    function getBoutSupporter(uint boutNum, uint supporterNum) external view returns (address);
+    function getBoutSupporter(uint boutId, uint bettorNum) external view returns (address);
 
-    function getBoutHiddenBet(uint boutNum, address supporter) external view returns (uint8);
+    function getBoutHiddenBet(uint boutId, address bettor) external view returns (uint8);
 
-    function getBoutRevealedBet(uint boutNum, address supporter) external view returns (BoutFighter);
+    function getBoutRevealedBet(uint boutId, address bettor) external view returns (BoutFighter);
 
-    function getBoutBetAmount(uint boutNum, address supporter) external view returns (uint);
+    function getBoutBetAmount(uint boutId, address bettor) external view returns (uint);
 
-    function getBoutWinningsClaimed(uint boutNum, address supporter) external view returns (bool);
+    function getBoutWinningsClaimed(uint boutId, address bettor) external view returns (bool);
 
-    function getBoutFighterId(uint boutNum, BoutFighter p) external view returns (uint);
+    function getBoutFighterId(uint boutId, BoutFighter p) external view returns (uint);
 
-    function getBoutFighterPot(uint boutNum, BoutFighter p) external view returns (uint);
+    function getBoutFighterPot(uint boutId, BoutFighter p) external view returns (uint);
 
-    function getBoutFighterPotBalance(uint boutNum, BoutFighter p) external view returns (uint);
+    function getBoutFighterPotBalance(uint boutId, BoutFighter p) external view returns (uint);
 }

--- a/src/interfaces/IInfoFacet.sol
+++ b/src/interfaces/IInfoFacet.sol
@@ -12,9 +12,9 @@ interface IInfoFacet {
 
     function getUserBoutsWinningsClaimed(address wallet) external view returns (uint);
 
-    function getUserBoutsSupported(address wallet) external view returns (uint);
+    function getUserBoutsBetOn(address wallet) external view returns (uint);
 
-    function getUserSupportedBoutAtIndex(address wallet, uint index) external view returns (uint);
+    function getUserBoutBetOnAtIndex(address wallet, uint index) external view returns (uint);
 
     function getBoutNonMappingInfo(uint boutId) external view returns (BoutNonMappingInfo memory);
 

--- a/src/libs/LibBetting.sol
+++ b/src/libs/LibBetting.sol
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.17 <0.9;
+
+import { SafeMath } from "lib/openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
+
+import { AppStorage, LibAppStorage, Bout, BoutState, BoutFighter } from "../Objects.sol";
+import { LibToken, LibTokenIds } from "src/libs/LibToken.sol";
+import { LibConstants } from "../libs/LibConstants.sol";
+import { LibEip712 } from "../libs/LibEip712.sol";
+import "../Errors.sol";
+
+library LibBetting {
+    using SafeMath for uint;
+
+    function getBout(uint boutId) internal view returns (Bout storage bout) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        bout = s.bouts[s.boutIdByIndex[boutId]];
+    }
+
+    function getBoutOrCreate(uint boutId) internal returns (Bout storage bout) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        bout = s.bouts[boutId];
+
+        if (uint(bout.state) == uint(BoutState.Uninitialized)) {
+            s.totalBouts++;
+            s.boutIdByIndex[s.totalBouts] = boutId;
+            bout.state = BoutState.Created;
+        }
+    }
+
+    function bet(uint boutId, address wallet, uint8 br, uint amount, uint deadline, uint8 sigV, bytes32 sigR, bytes32 sigS) external {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        Bout storage bout = getBoutOrCreate(boutId);
+
+        if (bout.state != BoutState.Created) {
+            revert BoutInWrongStateError(boutId, bout.state);
+        }
+
+        address server = s.addresses[LibConstants.SERVER_ADDRESS];
+        address bettor = wallet;
+
+        // recover signer
+        bytes32 digest = calculateBetSignature(server, bettor, boutId, br, amount, deadline);
+        address signer = LibEip712.recover(digest, sigV, sigR, sigS);
+
+        // final checks
+        if (signer != server) {
+            revert SignerMustBeServerError();
+        }
+        if (block.timestamp >= deadline) {
+            revert SignatureExpiredError();
+        }
+        if (amount < LibConstants.MIN_BET_AMOUNT) {
+            revert MinimumBetAmountError(boutId, bettor, amount);
+        }
+        if (br < 1 || br > 3) {
+            revert InvalidBetTargetError(boutId, bettor, br);
+        }
+
+        // replace old bet?
+        if (bout.hiddenBets[bettor] != 0) {
+            // refund old bet
+            bout.totalPot = bout.totalPot.sub(bout.betAmounts[bettor]);
+            LibToken.transfer(LibTokenIds.TOKEN_MEME, address(this), bettor, bout.betAmounts[bettor]);
+        }
+        // new bet?
+        else {
+            // add to bettor list
+            bout.numSupporters += 1;
+            bout.bettors[bout.numSupporters] = bettor;
+            bout.bettorIndexes[bettor] = bout.numSupporters;
+            // update user data
+            s.userTotalBoutsBetOn[bettor] += 1;
+            s.userBoutsBetOnByIndex[bettor][s.userTotalBoutsBetOn[bettor]] = boutId;
+        }
+
+        // add to pot
+        bout.totalPot = bout.totalPot.add(amount);
+        bout.betAmounts[bettor] = amount;
+        bout.hiddenBets[bettor] = br;
+
+        // transfer bet
+        claimWinnings(bettor, 1);
+        LibToken.transfer(LibTokenIds.TOKEN_MEME, bettor, address(this), amount);
+    }
+
+    function endBout(uint boutId, uint fighterAId, uint fighterBId, uint fighterAPot, uint fighterBPot, BoutFighter winner, uint8[] calldata revealValues) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        Bout storage bout = getBoutOrCreate(boutId);
+
+        if (bout.state != BoutState.Created) {
+            revert BoutInWrongStateError(boutId, bout.state);
+        }
+
+        if (winner != BoutFighter.FighterA && winner != BoutFighter.FighterB) {
+            revert InvalidWinnerError(boutId, winner);
+        }
+
+        if (fighterAPot.add(fighterBPot) != bout.totalPot) {
+            revert PotMismatchError(boutId, fighterAPot, fighterBPot, bout.totalPot);
+        }
+
+        bout.state = BoutState.Ended;
+
+        bout.revealValues = revealValues;
+
+        bout.fighterIds[BoutFighter.FighterA] = fighterAId;
+        bout.fighterPots[BoutFighter.FighterA] = fighterAPot;
+        bout.fighterPotBalances[BoutFighter.FighterA] = fighterAPot;
+
+        bout.fighterIds[BoutFighter.FighterB] = fighterBId;
+        bout.fighterPots[BoutFighter.FighterB] = fighterBPot;
+        bout.fighterPotBalances[BoutFighter.FighterB] = fighterBPot;
+
+        bout.winner = winner;
+        bout.loser = (winner == BoutFighter.FighterA ? BoutFighter.FighterB : BoutFighter.FighterA);
+
+        bout.endTime = block.timestamp;
+
+        s.endedBouts++;
+    }
+
+    function claimWinnings(address wallet, uint maxBoutsToClaim) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        uint totalWinnings = 0;
+        uint count = 0;
+        uint totalBoutsBetOn = s.userTotalBoutsBetOn[wallet];
+
+        for (uint i = s.userTotalBoutsWinningsClaimed[wallet] + 1; i <= totalBoutsBetOn && count < maxBoutsToClaim; i++) {
+            uint boutId = s.userBoutsBetOnByIndex[wallet][i];
+
+            (uint total, uint selfAmount, uint won) = getBoutWinnings(boutId, wallet);
+
+            Bout storage bout = s.bouts[boutId];
+
+            bout.winningsClaimed[wallet] = true;
+
+            if (total > 0) {
+                bout.fighterPotBalances[bout.winner] = bout.fighterPotBalances[bout.winner].sub(selfAmount);
+                bout.fighterPotBalances[bout.loser] = bout.fighterPotBalances[bout.loser].sub(won);
+                totalWinnings = totalWinnings.add(total);
+            }
+
+            s.userTotalBoutsWinningsClaimed[wallet]++;
+            count++;
+        }
+
+        // transfer winnings
+        if (totalWinnings > 0) {
+            LibToken.transfer(LibTokenIds.TOKEN_MEME, address(this), wallet, totalWinnings);
+        }
+    }
+
+    function getClaimableWinnings(address wallet) internal view returns (uint) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        uint winnings = 0;
+        uint totalBoutsBetOn = s.userTotalBoutsBetOn[wallet];
+
+        for (uint i = s.userTotalBoutsWinningsClaimed[wallet] + 1; i <= totalBoutsBetOn; i++) {
+            uint boutId = s.userBoutsBetOnByIndex[wallet][i];
+            (uint total, , ) = getBoutWinnings(boutId, wallet);
+            winnings = winnings.add(total);
+        }
+
+        return winnings;
+    }
+
+    function getBoutWinnings(uint boutId, address wallet) internal view returns (uint total, uint selfAmount, uint won) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        Bout storage bout = s.bouts[boutId];
+
+        // calculate which way player bet
+        BoutFighter bet = getRevealedBet(bout, wallet);
+
+        // bet on winner?
+        if (bet == bout.winner) {
+            // how much of losing pot do we get?
+            uint ratio = (bout.betAmounts[wallet] * 1000 ether) / bout.fighterPots[bout.winner];
+            won = (ratio * bout.fighterPots[bout.loser]) / 1000 ether;
+            // how much did we put in?
+            selfAmount = bout.betAmounts[wallet];
+            // total winnings
+            total = selfAmount + won;
+        }
+    }
+
+    function getRevealedBet(Bout storage bout, address wallet) internal view returns (BoutFighter bet) {
+        uint index = bout.bettorIndexes[wallet] - 1;
+        uint rPackedIndex = index >> 4;
+        uint8 r = (bout.revealValues[rPackedIndex] >> ((3 - (index % 4)) * 2)) & 3;
+        uint8 rawBet;
+        if (bout.hiddenBets[wallet] >= r) {
+            rawBet = bout.hiddenBets[wallet] - r;
+            // default to 0 if invalid
+            if (rawBet != 0 && rawBet != 1) {
+                rawBet = 0;
+            }
+        }
+        bet = BoutFighter(rawBet + 1);
+    }
+
+    function calculateBetSignature(address server, address wallet, uint boutId, uint8 br, uint amount, uint deadline) internal returns (bytes32) {
+        return
+            LibEip712.hashTypedDataV4(
+                keccak256(abi.encode(keccak256("calculateBetSignature(address,address,uint256,uint8,uint256,uint256)"), server, wallet, boutId, br, amount, deadline))
+            );
+    }
+}

--- a/src/libs/LibBetting.sol
+++ b/src/libs/LibBetting.sol
@@ -20,6 +20,7 @@ library LibBetting {
             s.totalBouts++;
             s.boutIdByIndex[s.totalBouts] = boutId;
             bout.state = BoutState.Created;
+            bout.createTime = block.timestamp;
         }
     }
 

--- a/src/libs/LibBetting.sol
+++ b/src/libs/LibBetting.sol
@@ -22,6 +22,7 @@ library LibBetting {
             s.boutIdByIndex[s.totalBouts] = boutId;
             bout.state = BoutState.Created;
             bout.createTime = block.timestamp;
+            bout.expiryTime = block.timestamp + LibConstants.DEFAULT_BOUT_EXPIRATION_TIME;
         }
     }
 
@@ -104,6 +105,10 @@ library LibBetting {
 
         if (fighterAPot.add(fighterBPot) != bout.totalPot) {
             revert PotMismatchError(boutId, fighterAPot, fighterBPot, bout.totalPot);
+        }
+
+        if (block.timestamp >= bout.expiryTime) {
+            revert BoutExpiredError(boutId, bout.expiryTime);
         }
 
         bout.state = BoutState.Ended;

--- a/src/libs/LibBetting.sol
+++ b/src/libs/LibBetting.sol
@@ -52,7 +52,12 @@ library LibBetting {
         if (bout.hiddenBets[wallet] != 0) {
             // refund old bet
             bout.totalPot = bout.totalPot.sub(bout.betAmounts[wallet]);
-            LibToken.transfer(LibTokenIds.TOKEN_MEME, address(this), wallet, bout.betAmounts[wallet]);
+            LibToken.transfer(
+                LibTokenIds.TOKEN_MEME,
+                address(this),
+                wallet,
+                bout.betAmounts[wallet]
+            );
         }
         // new bet?
         else {
@@ -74,7 +79,15 @@ library LibBetting {
         LibToken.transfer(LibTokenIds.TOKEN_MEME, wallet, address(this), amount);
     }
 
-    function endBout(uint boutId, uint fighterAId, uint fighterBId, uint fighterAPot, uint fighterBPot, BoutFighter winner, uint8[] calldata revealValues) internal {
+    function endBout(
+        uint boutId,
+        uint fighterAId,
+        uint fighterBId,
+        uint fighterAPot,
+        uint fighterBPot,
+        BoutFighter winner,
+        uint8[] calldata revealValues
+    ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         Bout storage bout = getBoutOrCreate(boutId);
@@ -125,7 +138,11 @@ library LibBetting {
         uint count = 0;
         uint totalBoutsBetOn = s.userTotalBoutsBetOn[wallet];
 
-        for (uint i = s.userTotalBoutsWinningsClaimed[wallet] + 1; i <= totalBoutsBetOn && count < maxBoutsToClaim; i++) {
+        for (
+            uint i = s.userTotalBoutsWinningsClaimed[wallet] + 1;
+            i <= totalBoutsBetOn && count < maxBoutsToClaim;
+            i++
+        ) {
             uint boutId = s.userBoutsBetOnByIndex[wallet][i];
 
             // if bout not yet ended
@@ -142,7 +159,9 @@ library LibBetting {
             bout.winningsClaimed[wallet] = true;
 
             if (total > 0) {
-                bout.fighterPotBalances[bout.winner] = bout.fighterPotBalances[bout.winner].sub(selfAmount);
+                bout.fighterPotBalances[bout.winner] = bout.fighterPotBalances[bout.winner].sub(
+                    selfAmount
+                );
                 bout.fighterPotBalances[bout.loser] = bout.fighterPotBalances[bout.loser].sub(won);
                 totalWinnings = totalWinnings.add(total);
             }
@@ -172,7 +191,10 @@ library LibBetting {
         return winnings;
     }
 
-    function getBoutWinnings(uint boutId, address wallet) internal view returns (uint total, uint selfAmount, uint won) {
+    function getBoutWinnings(
+        uint boutId,
+        address wallet
+    ) internal view returns (uint total, uint selfAmount, uint won) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         Bout storage bout = s.bouts[boutId];
@@ -192,7 +214,10 @@ library LibBetting {
         }
     }
 
-    function getRevealedBet(Bout storage bout, address wallet) internal view returns (BoutFighter bet) {
+    function getRevealedBet(
+        Bout storage bout,
+        address wallet
+    ) internal view returns (BoutFighter bet) {
         uint index = bout.bettorIndexes[wallet] - 1;
         uint rPackedIndex = index >> 4;
         uint8 r = (bout.revealValues[rPackedIndex] >> ((3 - (index % 4)) * 2)) & 3;
@@ -207,10 +232,29 @@ library LibBetting {
         bet = BoutFighter(rawBet + 1);
     }
 
-    function calculateBetSignature(address server, address wallet, uint boutId, uint8 br, uint amount, uint deadline) internal returns (bytes32) {
+    function calculateBetSignature(
+        address server,
+        address wallet,
+        uint boutId,
+        uint8 br,
+        uint amount,
+        uint deadline
+    ) internal returns (bytes32) {
         return
             LibEip712.hashTypedDataV4(
-                keccak256(abi.encode(keccak256("calculateBetSignature(address,address,uint256,uint8,uint256,uint256)"), server, wallet, boutId, br, amount, deadline))
+                keccak256(
+                    abi.encode(
+                        keccak256(
+                            "calculateBetSignature(address,address,uint256,uint8,uint256,uint256)"
+                        ),
+                        server,
+                        wallet,
+                        boutId,
+                        br,
+                        amount,
+                        deadline
+                    )
+                )
             );
     }
 }

--- a/src/libs/LibBetting.sol
+++ b/src/libs/LibBetting.sol
@@ -176,10 +176,9 @@ library LibBetting {
         }
     }
 
-    function getClaimableWinnings(address wallet) internal view returns (uint) {
+    function getClaimableWinnings(address wallet) internal view returns (uint winnings) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        uint winnings = 0;
         uint totalBoutsBetOn = s.userTotalBoutsBetOn[wallet];
 
         for (uint i = s.userTotalBoutsWinningsClaimed[wallet] + 1; i <= totalBoutsBetOn; i++) {
@@ -187,8 +186,6 @@ library LibBetting {
             (uint total, , ) = getBoutWinnings(boutId, wallet);
             winnings = winnings.add(total);
         }
-
-        return winnings;
     }
 
     function getBoutWinnings(

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -2,15 +2,18 @@
 pragma solidity >=0.8.17 <0.9;
 
 library LibConstants {
+    // EIP712 domain name
     bytes32 internal constant EIP712_DOMAIN_HASH = keccak256("EIP712_DOMAIN_HASH");
-
+    // address of MEME token contract
     bytes32 internal constant MEME_TOKEN_ADDRESS = keccak256("MEME_TOKEN_ADDRESS");
+    // wallet address of the server
     bytes32 internal constant SERVER_ADDRESS = keccak256("SERVER_ADDRESS");
+    // wallet address of the treasury
     bytes32 internal constant TREASURY_ADDRESS = keccak256("TREASURY_ADDRESS");
-
+    // the minimum amount of tokens that can be bet on a bout
     uint internal constant MIN_BET_AMOUNT = 10 ether;
-
-    uint internal constant TOKEN_MEME = 1;
-
+    // time before a bout expires unless it is finalized
+    uint internal constant DEFAULT_BOUT_EXPIRATION_TIME = 1 days;
+    // address of the WMATIC token contract on Polygon mainnet
     address internal constant WMATIC_POLYGON_ADDRESS = 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270;
 }

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -14,9 +14,3 @@ library LibConstants {
 
     address internal constant WMATIC_POLYGON_ADDRESS = 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270;
 }
-
-library LibTokenIds {
-    uint256 internal constant TOKEN_MEME = 1;
-    uint256 internal constant BROADCAST_MSG = 2;
-    uint256 internal constant SUPPORTER_INFLUENCE = 3;
-}

--- a/src/libs/LibLinkedList.sol
+++ b/src/libs/LibLinkedList.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.17 <0.9;
+
+import { BoutList, BoutListNode } from "../Objects.sol";
+
+library LibLinkedList {
+    function addToBoutList(BoutList storage list, uint boutId) internal {
+        list.len++;
+
+        list.nextId++;
+        list.nodes[list.nextId] = BoutListNode({ boutId: boutId, prev: 0, next: 0 });
+
+        // set as first node if necessary
+        if (list.head == 0) {
+            list.head = list.nextId;
+            list.tail = list.nextId;
+        }
+        // add to end of list
+        else {
+            list.nodes[list.tail].next = list.nextId;
+            list.nodes[list.nextId].prev = list.tail;
+            list.tail = list.nextId;
+        }
+    }
+
+    function removeFromBoutList(BoutList storage list, BoutListNode storage node) internal {
+        list.len--;
+
+        // was first item?
+        if (node.prev == 0) {
+            list.head = node.next;
+            // set new head's prev to 0
+            if (list.head != 0) {
+                list.nodes[list.head].prev = 0;
+            } else {
+                // if no head, no tail
+                list.tail = 0;
+            }
+        } else {
+            // set prev item's next to next item
+            list.nodes[node.prev].next = node.next;
+            // set next item's prev to prev item
+            if (node.next != 0) {
+                list.nodes[node.next].prev = node.prev;
+            } else {
+                // set a new tail if necessary
+                list.tail = node.prev;
+            }
+        }
+    }
+}

--- a/src/libs/LibToken.sol
+++ b/src/libs/LibToken.sol
@@ -43,3 +43,9 @@ library LibToken {
         emit Transfer(wallet, address(0), amount);
     }
 }
+
+library LibTokenIds {
+    uint256 internal constant TOKEN_MEME = 1;
+    uint256 internal constant BROADCAST_MSG = 2;
+    uint256 internal constant SUPPORTER_INFLUENCE = 3;
+}

--- a/test/BettingTest.sol
+++ b/test/BettingTest.sol
@@ -561,7 +561,7 @@ contract BettingTest is TestBaseContract {
 
         uint numBouts = 5;
 
-        uint[] memory boutIds = new uint[](numBouts);
+        boutIds = new uint[](numBouts);
 
         for (uint i = 0; i < numBouts; i += 1) {
             boutIds[i] = 100 + i;
@@ -646,7 +646,7 @@ contract BettingTest is TestBaseContract {
 
         uint numBouts = 5;
 
-        uint[] memory boutIds = new uint[](numBouts);
+        boutIds = new uint[](numBouts);
 
         for (uint i = 0; i < numBouts; i += 1) {
             boutIds[i] = 100 + i;
@@ -738,7 +738,7 @@ contract BettingTest is TestBaseContract {
         BettingScenario memory scen = _getScenario1();
 
         // check claimable winnings
-        for (uint i = 0; i < scen.players.length; i++) {
+        for (uint i = 1; i < 2; i++) {
             Wallet memory player = scen.players[i];
 
             uint winnings = proxy.getClaimableWinnings(player.addr);

--- a/test/BettingTest.sol
+++ b/test/BettingTest.sol
@@ -885,7 +885,7 @@ contract BettingTest is TestBaseContract {
         BettingScenario memory scen = _getScenario1();
 
         ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
-        Wallet memory player = scen.players[1]; // 2nd and 4th players are winners
+        Wallet memory player = scen.players[1]; // 2nd player is a winner
         assertEq(uint(scen.betTargets[1]), uint(scen.winner));
 
         uint winningsClaimed = 0;
@@ -939,6 +939,8 @@ contract BettingTest is TestBaseContract {
             proxyMemeTokenBalance - winningsClaimed,
             "proxy meme token balance"
         );
+
+        assertEq(proxy.getUserBoutsWinningsClaimed(player.addr), 2, "bouts claimed");
 
         // check that there are still winnings to claim for this player
         assertEq(

--- a/test/BettingTest.sol
+++ b/test/BettingTest.sol
@@ -5,7 +5,8 @@ import "forge-std/Test.sol";
 import "../src/Errors.sol";
 import { BoutNonMappingInfo, BoutFighter, BoutState } from "../src/Objects.sol";
 import { Wallet, TestBaseContract } from "./utils/TestBaseContract.sol";
-import { LibConstants, LibTokenIds } from "../src/libs/LibConstants.sol";
+import { LibConstants } from "../src/libs/LibConstants.sol";
+import { LibTokenIds } from "../src/libs/LibToken.sol";
 
 contract BettingTest is TestBaseContract {
     uint fighterAId = 1;
@@ -24,15 +25,19 @@ contract BettingTest is TestBaseContract {
     function testBetWithInvalidBoutState() public {
         uint boutId = 100;
 
+        // do signature
+        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
+
         // state: Ended
         proxy._testSetBoutState(boutId, BoutState.Ended);
-        vm.expectRevert(abi.encodePacked(BoutInWrongStateError.selector, uint256(1), uint256(BoutState.Ended)));
-        proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, 1, "0x", "0x");
+        vm.expectRevert(abi.encodePacked(BoutInWrongStateError.selector, uint(100), uint256(BoutState.Ended)));
+        proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
 
         // state: Cancelled
         proxy._testSetBoutState(boutId, BoutState.Cancelled);
-        vm.expectRevert(abi.encodePacked(BoutInWrongStateError.selector, uint256(1), uint256(BoutState.Cancelled)));
-        proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, 1, "0x", "0x");
+        vm.expectRevert(abi.encodePacked(BoutInWrongStateError.selector, uint(100), uint256(BoutState.Cancelled)));
+        proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
     }
 
     function testBetWithBadSigner() public {
@@ -40,7 +45,7 @@ contract BettingTest is TestBaseContract {
 
         // do signature
         address signer = vm.addr(123);
-        bytes32 digest = proxy.calculateBetSignature(signer, account0, 1, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(signer, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(123, digest);
 
         vm.expectRevert(SignerMustBeServerError.selector);
@@ -51,7 +56,7 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, 1, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp - 1);
+        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp - 1);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
         vm.expectRevert(SignatureExpiredError.selector);
@@ -62,10 +67,10 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, 1, 1, LibConstants.MIN_BET_AMOUNT - 1, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT - 1, block.timestamp + 1000);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
-        vm.expectRevert(abi.encodeWithSelector(MinimumBetAmountError.selector, 1, address(this), LibConstants.MIN_BET_AMOUNT - 1));
+        vm.expectRevert(abi.encodeWithSelector(MinimumBetAmountError.selector, uint(boutId), address(this), LibConstants.MIN_BET_AMOUNT - 1));
         proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT - 1, block.timestamp + 1000, v, r, s);
     }
 
@@ -75,10 +80,10 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, 1, br, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, br, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidBetTargetError.selector, 1, address(this), br));
+        vm.expectRevert(abi.encodeWithSelector(InvalidBetTargetError.selector, boutId, address(this), br));
         proxy.bet(boutId, br, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
     }
 
@@ -86,7 +91,7 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, 1, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
         uint256 userBalance = proxy.tokenBalanceOf(LibTokenIds.TOKEN_MEME, address(this));
@@ -101,33 +106,33 @@ contract BettingTest is TestBaseContract {
         (Wallet[] memory players, uint[] memory betAmounts, , , , , ) = _getScenario1();
 
         // initialy no bouts
-        assertEq(proxy.totalBouts(), 0, "no bouts at start");
+        assertEq(proxy.getTotalBouts(), 0, "no bouts at start");
 
         // place bet
         Wallet memory player = players[0];
         _bet(player.addr, boutId, 1, betAmounts[0]);
 
         // check total bouts
-        assertEq(proxy.totalBouts(), 1, "total bouts");
+        assertEq(proxy.getTotalBouts(), 1, "total bouts");
         assertEq(proxy.getBoutIdByIndex(1), boutId, "bout id by index");
 
         // check bout basic state
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
         assertEq(uint(bout.state), uint(BoutState.Created), "created");
         assertEq(bout.numSupporters, 1, "no. of bettors");
-        assertEq(bout.totalPot, LibConstants.MIN_BET_AMOUNT * 15, "total pot");
-        assertEq(bout.state, BoutState.Created, "bout state");
-        assertEq(bout.winner, BoutFighter.Uninitialized, "bout winner");
-        assertEq(bout.loser, BoutFighter.Uninitialized, "bout loser");
-        assertEq(bout.fighterPots[BoutFighter.FighterA], 0, "fighter A pot");
-        assertEq(bout.fighterPots[BoutFighter.FighterB], 0, "fighter B pot");
-        assertEq(bout.fighterPotBalances[BoutFighter.FighterA], 0, "fighter A pot balance");
-        assertEq(bout.fighterPotBalances[BoutFighter.FighterB], 0, "fighter B pot balance");
+        assertEq(bout.totalPot, betAmounts[0], "total pot");
+        assertEq(uint(bout.winner), uint(BoutFighter.Uninitialized), "bout winner");
+        assertEq(uint(bout.loser), uint(BoutFighter.Uninitialized), "bout loser");
+
+        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), 0, "fighter A pot");
+        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), 0, "fighter B pot");
+        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA), 0, "fighter A pot balance");
+        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB), 0, "fighter B pot balance");
 
         // check player data
-        assertEq(proxy.getBoutSupporter(boutId, i), player.addr, "bettor address");
+        assertEq(proxy.getBoutSupporter(boutId, 1), player.addr, "bettor address");
         assertEq(proxy.getBoutHiddenBet(boutId, player.addr), 1, "bettor hidden bet");
-        assertEq(proxy.getBoutBetAmount(boutId, player.addr), betAmounts[i - 1], "bettor bet amount");
+        assertEq(proxy.getBoutBetAmount(boutId, player.addr), betAmounts[0], "bettor bet amount");
         assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
 
         // check MEME balances
@@ -141,27 +146,29 @@ contract BettingTest is TestBaseContract {
         (Wallet[] memory players, uint[] memory betAmounts, , , , , ) = _getScenario1();
 
         // place bets
+        uint totalBetAmount = 0;
         for (uint i = 0; i < players.length; i += 1) {
             Wallet memory player = players[i];
+            totalBetAmount += betAmounts[i];
             _bet(player.addr, boutId, 1, betAmounts[i]);
         }
 
         // check total bouts
-        assertEq(proxy.totalBouts(), 1, "still only 1 bout created");
+        assertEq(proxy.getTotalBouts(), 1, "still only 1 bout created");
         assertEq(proxy.getBoutIdByIndex(1), boutId, "bout id by index");
 
         // check bout basic state
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
         assertEq(bout.numSupporters, 5, "no. of bettors");
-        assertEq(bout.totalPot, LibConstants.MIN_BET_AMOUNT * 15, "total pot");
+        assertEq(bout.totalPot, totalBetAmount, "total pot");
 
         // check bettor data
-        for (uint i = 1; i <= players.length; i += 1) {
-            Wallet memory player = players[i - 1];
+        for (uint i = 0; i < players.length; i += 1) {
+            Wallet memory player = players[i];
 
-            assertEq(proxy.getBoutSupporter(boutId, i), player.addr, "bettor address");
+            assertEq(proxy.getBoutSupporter(boutId, i + 1), player.addr, "bettor address");
             assertEq(proxy.getBoutHiddenBet(boutId, player.addr), 1, "bettor hidden bet");
-            assertEq(proxy.getBoutBetAmount(boutId, player.addr), betAmounts[i - 1], "bettor bet amount");
+            assertEq(proxy.getBoutBetAmount(boutId, player.addr), betAmounts[i], "bettor bet amount");
             assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
         }
 
@@ -190,7 +197,7 @@ contract BettingTest is TestBaseContract {
         assertEq(proxy.getBoutSupporter(boutId, 1), player1.addr, "bettor address");
         assertEq(proxy.getBoutHiddenBet(boutId, player1.addr), 1, "bettor hidden bet");
         assertEq(proxy.getBoutBetAmount(boutId, player1.addr), bout.totalPot, "bettor bet amount");
-        assertEq(proxy.getUserBoutsSupported(player1.addr), boutId, "user supported bouts");
+        assertEq(proxy.getUserBoutsSupported(player1.addr), 1, "user supported bouts");
 
         // check MEME balances
         assertEq(memeToken.balanceOf(player1.addr), LibConstants.MIN_BET_AMOUNT * 10, "MEME balance");
@@ -221,554 +228,6 @@ contract BettingTest is TestBaseContract {
     // Reveal bets
     //
     // ------------------------------------------------------ //
-
-    function testRevealBetsMustBeDoneByServer() public {
-        // create bout and place bets
-        uint boutId = testBetMultipleSucceeds();
-
-        address dummyServer = vm.addr(123);
-
-        uint8[] memory rPacked = new uint8[](0);
-
-        vm.prank(dummyServer);
-        vm.expectRevert(CallerMustBeServerError.selector);
-        proxy.revealBets(boutId, 0, rPacked);
-
-        proxy.setAddress(LibConstants.SERVER_ADDRESS, dummyServer);
-
-        vm.prank(dummyServer);
-        proxy.revealBets(boutId, 0, rPacked);
-    }
-
-    function testRevealBetsInWrongState() public {
-        // create bout and place bets
-        uint boutId = testBetMultipleSucceeds();
-
-        uint8[] memory rPacked = new uint8[](0);
-
-        // state: Unknown
-        proxy._testSetBoutState(boutId, BoutState.Unknown);
-        vm.prank(server.addr);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Unknown));
-        proxy.revealBets(boutId, 0, rPacked);
-
-        // state: Ended
-        proxy._testSetBoutState(boutId, BoutState.Ended);
-        vm.prank(server.addr);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Ended));
-        proxy.revealBets(boutId, 0, rPacked);
-    }
-
-    function testRevealBetsEmitsEvent() public {
-        // create bout and place bets
-        uint boutId = testBetMultipleSucceeds();
-
-        uint8[] memory rPacked = new uint8[](2);
-
-        vm.recordLogs();
-
-        vm.prank(server.addr);
-        proxy.revealBets(boutId, 3, rPacked);
-
-        // check logs
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries[0].topics.length, 1, "Invalid event count");
-        assertEq(entries[0].topics[0], keccak256("BetsRevealed(uint256,uint256)"));
-        (uint eBoutId, uint count) = abi.decode(entries[0].data, (uint, uint));
-        assertEq(eBoutId, boutId, "boutId incorrect");
-        assertEq(count, 3, "count incorrect");
-    }
-
-    function testRevealBets() public returns (uint boutId) {
-        // create bout and place bets
-        boutId = testBetMultipleSucceeds();
-
-        (Wallet[] memory players, uint[] memory betAmounts, BoutFighter[] memory betTargets, uint8[] memory rPacked, , , ) = _getScenario1();
-
-        vm.prank(server.addr);
-        proxy.revealBets(boutId, 5, rPacked);
-
-        // num of revealed bets
-        BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
-        assertEq(uint(bout.state), uint(BoutState.BetsRevealed), "state");
-        assertGt(bout.revealTime, 0, "reveal time");
-        assertEq(bout.numRevealedBets, 5, "num revealed bets (1st call)");
-
-        // now let's check the revealed bets
-        for (uint i = 0; i < players.length; i++) {
-            assertEq(uint(proxy.getBoutRevealedBet(boutId, players[i].addr)), uint(betTargets[i]), "revealed bet");
-        }
-
-        // check the fighter pots
-        uint aPot = betAmounts[0] + betAmounts[2] + betAmounts[4];
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), aPot, "fighter A pot");
-        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA), aPot, "fighter A pot balance");
-
-        uint bPot = betAmounts[1] + betAmounts[3];
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), bPot, "fighter B pot");
-        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB), bPot, "fighter B pot balance");
-    }
-
-    function testRevealBetsWithMultipleCalls() public {
-        // create bout and place bets
-        uint boutId = testBetMultipleSucceeds();
-
-        (Wallet[] memory players, uint[] memory betAmounts, BoutFighter[] memory betTargets, uint8[] memory rPacked, , , ) = _getScenario1();
-
-        uint8[] memory rPacked1 = new uint8[](1);
-        rPacked1[0] = rPacked[0];
-        uint8[] memory rPacked2 = new uint8[](1);
-        rPacked2[0] = rPacked[1];
-
-        // first call
-        vm.prank(server.addr);
-        proxy.revealBets(boutId, 4, rPacked1);
-
-        assertEq(proxy.getBoutNonMappingInfo(boutId).numRevealedBets, 4, "num revealed bets (1st call)");
-        for (uint i = 0; i < 4; i++) {
-            assertEq(uint(proxy.getBoutRevealedBet(boutId, players[i].addr)), uint(betTargets[i]), "revealed bet");
-        }
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player5.addr)), uint(BoutFighter.Unknown), "revealed bet 5");
-
-        // 2nd call
-        vm.prank(server.addr);
-        proxy.revealBets(boutId, 1, rPacked2);
-
-        assertEq(proxy.getBoutNonMappingInfo(boutId).numRevealedBets, 5, "num revealed bets (2nd call)");
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player5.addr)), uint(BoutFighter.FighterA), "revealed bet 5");
-
-        // check the fighter pots
-        uint aPot = betAmounts[0] + betAmounts[2] + betAmounts[4];
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), aPot, "fighter A pot");
-
-        uint bPot = betAmounts[1] + betAmounts[3];
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), bPot, "fighter B pot");
-    }
-
-    function testRevealBetsWithBadRValues() public {
-        // create bout and place bets
-        uint boutId = testBetMultipleSucceeds();
-
-        /*
-        Since B+R = 1, we'll use 2 and 3 here to cause an underflow. 
-        The bet value should default to 0.
-
-        11 10 11 10, 11 00 00 00
-        */
-        uint8[] memory rPacked = new uint8[](2);
-        rPacked[0] = 238; // 11 10 11 10
-        rPacked[1] = 192; // 11 00 00 00
-
-        vm.prank(server.addr);
-        proxy.revealBets(boutId, 5, rPacked);
-
-        // now let's check the revealed bets
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player1.addr)), uint(BoutFighter.FighterA), "revealed bet 1");
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player2.addr)), uint(BoutFighter.FighterA), "revealed bet 2");
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player3.addr)), uint(BoutFighter.FighterA), "revealed bet 3");
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player4.addr)), uint(BoutFighter.FighterA), "revealed bet 4");
-        assertEq(uint(proxy.getBoutRevealedBet(boutId, player5.addr)), uint(BoutFighter.FighterA), "revealed bet 5");
-
-        // check the fighter pots
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), proxy.getBoutNonMappingInfo(boutId).totalPot, "fighter A pot");
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), 0, "fighter B pot");
-    }
-
-    function testRevealBetsWhenAlreadyFullyRevealed() public {
-        // create bout and place bets
-        uint boutId = testBetMultipleSucceeds();
-
-        vm.startPrank(server.addr);
-
-        uint8[] memory rPacked = new uint8[](2);
-        proxy.revealBets(boutId, 5, rPacked);
-
-        // doing again is ok
-        proxy.revealBets(boutId, 1, rPacked);
-
-        assertEq(proxy.getBoutNonMappingInfo(boutId).numRevealedBets, 5, "num revealed bets");
-
-        vm.stopPrank();
-    }
-
-    // ------------------------------------------------------ //
-    //
-    // End bout
-    //
-    // ------------------------------------------------------ //
-
-    function testEndBoutMustBeDoneByServer() public {
-        // create bout, place bets, reveal bets
-        uint boutId = testRevealBets();
-
-        address dummyServer = vm.addr(123);
-
-        vm.prank(dummyServer);
-        vm.expectRevert(CallerMustBeServerError.selector);
-        proxy.endBout(boutId, BoutFighter.FighterA);
-
-        proxy.setAddress(LibConstants.SERVER_ADDRESS, dummyServer);
-
-        vm.prank(dummyServer);
-        proxy.endBout(boutId, BoutFighter.FighterA);
-    }
-
-    function testEndBoutEmitsEvent() public {
-        // create bout, place bets, reveal bets
-        uint boutId = testRevealBets();
-
-        vm.recordLogs();
-
-        vm.prank(server.addr);
-        proxy.endBout(boutId, BoutFighter.FighterA);
-
-        // check logs
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries[0].topics.length, 1, "Invalid event count");
-        assertEq(entries[0].topics[0], keccak256("BoutEnded(uint256)"));
-        uint eBoutId = abi.decode(entries[0].data, (uint));
-        assertEq(eBoutId, boutId, "boutId incorrect");
-    }
-
-    function testEndBoutWithInvalidState() public {
-        // create bout, place bets, reveal bets
-        uint boutId = testRevealBets();
-
-        vm.startPrank(server.addr);
-
-        // state: Unknown
-        proxy._testSetBoutState(boutId, BoutState.Unknown);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Unknown));
-        proxy.endBout(boutId, BoutFighter.FighterA);
-
-        // state: Created
-        proxy._testSetBoutState(boutId, BoutState.Created);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Created));
-        proxy.endBout(boutId, BoutFighter.FighterA);
-
-        // state: Ended
-        proxy._testSetBoutState(boutId, BoutState.Ended);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Ended));
-        proxy.endBout(boutId, BoutFighter.FighterA);
-
-        vm.stopPrank();
-    }
-
-    function testEndBoutWithInvalidWinner() public {
-        // create bout, place bets, reveal bets
-        uint boutId = testRevealBets();
-
-        vm.prank(server.addr);
-        vm.expectRevert(abi.encodeWithSelector(InvalidWinnerError.selector, 1, BoutFighter.Unknown));
-        proxy.endBout(boutId, BoutFighter.Unknown);
-    }
-
-    function testEndBout() public returns (uint boutId) {
-        // create bout, place bets, reveal bets
-        boutId = testRevealBets();
-
-        (, , , , BoutFighter winner, BoutFighter loser, ) = _getScenario1();
-
-        vm.prank(server.addr);
-        proxy.endBout(boutId, winner);
-
-        // check the state
-        BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
-        assertEq(uint(bout.state), uint(BoutState.Ended), "state");
-        assertGt(bout.endTime, 0, "end time");
-        assertEq(uint(bout.winner), uint(winner), "winner");
-        assertEq(uint(bout.loser), uint(loser), "loser");
-
-        // check global state
-        assertEq(proxy.getEndedBouts(), boutId, "ended bouts");
-    }
-
-    // ------------------------------------------------------ //
-    //
-    // Test processing multiple bouts
-    //
-    // ------------------------------------------------------ //
-
-    function testCompleteMultipleBouts() internal returns (uint[] memory boutIds) {
-        (
-            Wallet[] memory players,
-            uint[] memory betAmounts,
-            BoutFighter[] memory betTargets,
-            uint8[] memory rPacked,
-            BoutFighter winner,
-            BoutFighter loser,
-            uint[] memory expectedWinnings
-        ) = _getScenario1();
-
-        boutIds = new uint[](5);
-
-        // create bout, place bets, reveal bets, end bout
-        for (uint i = 0; i < 5; i += 1) {
-            vm.prank(server.addr);
-            proxy.createBout(fighterAId, fighterBId);
-
-            boutIds[i] = proxy.getTotalBouts();
-
-            for (uint j = 0; j < players.length; j += 1) {
-                _bet(players[j].addr, boutIds[i], 1, betAmounts[j]);
-            }
-
-            vm.startPrank(server.addr);
-            proxy.revealBets(boutIds[i], 5, rPacked);
-            proxy.endBout(boutIds[i], winner);
-            vm.stopPrank();
-        }
-
-        // check total bouts
-        assertEq(proxy.getTotalBouts(), boutIds.length, "total bouts");
-    }
-
-    // ------------------------------------------------------ //
-    //
-    // Claim winnings
-    //
-    // ------------------------------------------------------ //
-
-    function testGetClaimableWinningsForSingleBout() public {
-        // create bout, place bets, reveal bets, end bout
-        testEndBout();
-
-        (Wallet[] memory players, , , , , , uint[] memory expectedWinnings) = _getScenario1();
-
-        // check claimable winnings
-        for (uint i = 0; i < players.length; i++) {
-            Wallet memory player = players[i];
-
-            uint winnings = proxy.getClaimableWinnings(player.addr);
-
-            assertEq(winnings, expectedWinnings[i], "winnings");
-        }
-    }
-
-    function testGetClaimableWinningsForMultipleBouts() public {
-        uint[] memory boutIds = testCompleteMultipleBouts();
-
-        (Wallet[] memory players, , , , , , uint[] memory expectedWinnings) = _getScenario1();
-
-        // check claimable winnings
-        for (uint i = 0; i < players.length; i++) {
-            Wallet memory player = players[i];
-
-            uint winnings = proxy.getClaimableWinnings(player.addr);
-
-            assertEq(winnings, expectedWinnings[i] * boutIds.length, "winnings");
-        }
-    }
-
-    // use this to avoid stack too deep errors
-    struct ClaimWinningsLoopValues {
-        uint winnerPotPrevBalance;
-        uint loserPotPrevBalance;
-        uint winnerPotPostBalance;
-        uint loserPotPostBalance;
-        uint proxyMemeTokenBalance;
-        uint total;
-        uint selfAmount;
-        uint won;
-    }
-
-    function testClaimWinningsForSingleBout() public {
-        // create bout, place bets, reveal bets, end bout
-        uint boutId = testEndBout();
-
-        (
-            Wallet[] memory players,
-            uint[] memory betAmounts,
-            BoutFighter[] memory betTargets,
-            ,
-            BoutFighter winner,
-            BoutFighter loser,
-            uint[] memory expectedWinnings
-        ) = _getScenario1();
-
-        ClaimWinningsLoopValues memory v;
-        Wallet memory player;
-
-        // check claimable winnings
-        for (uint i = 0; i < players.length; i++) {
-            player = players[i];
-
-            // get fighter pot balances
-            v.winnerPotPrevBalance = proxy.getBoutFighterPotBalance(boutId, winner);
-            v.loserPotPrevBalance = proxy.getBoutFighterPotBalance(boutId, loser);
-
-            // get meme token balance of proxy
-            v.proxyMemeTokenBalance = memeToken.balanceOf(proxyAddress);
-
-            // get bout winnings for this player
-            (v.total, v.selfAmount, v.won) = proxy.getBoutWinnings(boutId, player.addr);
-
-            // make claim
-            proxy.claimWinnings(player.addr, 1);
-
-            // check fighter pot balances
-            v.winnerPotPostBalance = proxy.getBoutFighterPotBalance(boutId, winner);
-            v.loserPotPostBalance = proxy.getBoutFighterPotBalance(boutId, loser);
-            if (betTargets[i] == winner) {
-                assertEq(v.winnerPotPostBalance, v.winnerPotPrevBalance - v.selfAmount);
-                assertEq(v.loserPotPostBalance, v.loserPotPrevBalance - v.won);
-            } else {
-                assertEq(v.winnerPotPostBalance, v.winnerPotPrevBalance);
-                assertEq(v.loserPotPostBalance, v.loserPotPrevBalance);
-            }
-
-            // check bout winnings claimed status
-            assertEq(proxy.getBoutWinningsClaimed(boutId, player.addr), true, "bout winnings claimed");
-
-            // check that tokens were transferred
-            assertEq(memeToken.balanceOf(player.addr), v.total, "total winnings");
-            assertEq(memeToken.balanceOf(proxyAddress), v.proxyMemeTokenBalance - v.total, "proxy meme token balance");
-
-            // check that there no more winnings to claim for this player
-            assertEq(proxy.getClaimableWinnings(player.addr), 0, "all winnings claimed");
-        }
-    }
-
-    function testClaimWinningsForMultipleBouts() public {
-        // create bout, place bets, reveal bets, end bout
-        uint[] memory boutIds = testCompleteMultipleBouts();
-
-        (
-            Wallet[] memory players,
-            uint[] memory betAmounts,
-            BoutFighter[] memory betTargets,
-            ,
-            BoutFighter winner,
-            BoutFighter loser,
-            uint[] memory expectedWinnings
-        ) = _getScenario1();
-
-        ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
-        Wallet memory player = players[1]; // 2nd and 4th players are winners
-        assertEq(uint(betTargets[1]), uint(winner));
-
-        uint winningsClaimed = 0;
-        uint totalWinnings = proxy.getClaimableWinnings(player.addr);
-        uint proxyMemeTokenBalance = memeToken.balanceOf(proxyAddress);
-
-        // get pre-values
-        for (uint i = 0; i < boutIds.length; i++) {
-            uint boutId = boutIds[i];
-
-            // get fighter pot balances
-            v[i].winnerPotPrevBalance = proxy.getBoutFighterPotBalance(boutId, winner);
-            v[i].loserPotPrevBalance = proxy.getBoutFighterPotBalance(boutId, loser);
-
-            // get bout winnings for this player
-            (v[i].total, v[i].selfAmount, v[i].won) = proxy.getBoutWinnings(boutId, player.addr);
-
-            winningsClaimed += v[i].total;
-        }
-
-        // have winnings to claim
-        assertGt(winningsClaimed, 0, "have winnings to claim");
-        assertEq(winningsClaimed, totalWinnings, "have winnings to claim equal to total");
-
-        // make claim
-        proxy.claimWinnings(player.addr, boutIds.length);
-
-        // check post-values
-        for (uint i = 0; i < boutIds.length; i++) {
-            uint boutId = boutIds[i];
-
-            // check fighter pot balances
-            v[i].winnerPotPostBalance = proxy.getBoutFighterPotBalance(boutId, winner);
-            v[i].loserPotPostBalance = proxy.getBoutFighterPotBalance(boutId, loser);
-            assertEq(v[i].winnerPotPostBalance, v[i].winnerPotPrevBalance - v[i].selfAmount);
-            assertEq(v[i].loserPotPostBalance, v[i].loserPotPrevBalance - v[i].won);
-
-            // check bout winnings claimed status
-            assertEq(proxy.getBoutWinningsClaimed(boutId, player.addr), true, "bout winnings claimed");
-        }
-
-        // check that tokens were transferred
-        assertEq(memeToken.balanceOf(player.addr), winningsClaimed, "total winnings");
-        assertEq(memeToken.balanceOf(proxyAddress), proxyMemeTokenBalance - winningsClaimed, "proxy meme token balance");
-
-        // check that there no more winnings to claim for this player
-        assertEq(proxy.getClaimableWinnings(player.addr), 0, "all winnings claimed");
-    }
-
-    function testClaimWinningsForMultipleBoutsSubset() public {
-        // create bout, place bets, reveal bets, end bout
-        uint[] memory boutIds = testCompleteMultipleBouts();
-
-        (
-            Wallet[] memory players,
-            uint[] memory betAmounts,
-            BoutFighter[] memory betTargets,
-            ,
-            BoutFighter winner,
-            BoutFighter loser,
-            uint[] memory expectedWinnings
-        ) = _getScenario1();
-
-        ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
-        Wallet memory player = players[1]; // 2nd and 4th players are winners
-        assertEq(uint(betTargets[1]), uint(winner));
-
-        uint winningsClaimed = 0;
-        uint totalWinnings = proxy.getClaimableWinnings(player.addr);
-        uint proxyMemeTokenBalance = memeToken.balanceOf(proxyAddress);
-
-        uint MAX_BOUTS = 2;
-
-        // get pre-values
-        for (uint i = 0; i < MAX_BOUTS; i++) {
-            uint boutId = boutIds[i];
-
-            // get fighter pot balances
-            v[i].winnerPotPrevBalance = proxy.getBoutFighterPotBalance(boutId, winner);
-            v[i].loserPotPrevBalance = proxy.getBoutFighterPotBalance(boutId, loser);
-
-            // get bout winnings for this player
-            (v[i].total, v[i].selfAmount, v[i].won) = proxy.getBoutWinnings(boutId, player.addr);
-
-            winningsClaimed += v[i].total;
-        }
-
-        assertGt(winningsClaimed, 0, "have winnings to claim");
-        assertLt(winningsClaimed, totalWinnings, "have winnings to claim less than total");
-
-        // make claim
-        proxy.claimWinnings(player.addr, MAX_BOUTS);
-
-        // check post-values
-        for (uint i = 0; i < MAX_BOUTS; i++) {
-            uint boutId = boutIds[i];
-
-            // check fighter pot balances
-            v[i].winnerPotPostBalance = proxy.getBoutFighterPotBalance(boutId, winner);
-            v[i].loserPotPostBalance = proxy.getBoutFighterPotBalance(boutId, loser);
-            assertEq(v[i].winnerPotPostBalance, v[i].winnerPotPrevBalance - v[i].selfAmount);
-            assertEq(v[i].loserPotPostBalance, v[i].loserPotPrevBalance - v[i].won);
-
-            // check bout winnings claimed status
-            assertEq(proxy.getBoutWinningsClaimed(boutId, player.addr), true, "bout winnings claimed");
-        }
-
-        // check that tokens were transferred
-        assertEq(memeToken.balanceOf(player.addr), winningsClaimed, "total winnings");
-        assertEq(memeToken.balanceOf(proxyAddress), proxyMemeTokenBalance - winningsClaimed, "proxy meme token balance");
-
-        // check that there are still winnings to claim for this player
-        assertEq(proxy.getClaimableWinnings(player.addr), totalWinnings - winningsClaimed, "some winnings claimed");
-    }
-
-    // ------------------------------------------------------ //
-    //
-    // Edge cases
-    //
-    // ------------------------------------------------------ //
-
-    // function testWhenAllBetsAreOnOneFighter() public {
-    //     // TODO...
-    // }
 
     // ------------------------------------------------------ //
     //

--- a/test/BettingTest.sol
+++ b/test/BettingTest.sol
@@ -822,7 +822,7 @@ contract BettingTest is TestBaseContract {
 
         ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
         Wallet memory player = scen.players[1]; // 2nd and 4th players are winners
-        // assertEq(scen.betTargets[1], scen.winner);
+        assertEq(uint(scen.betTargets[1]), uint(scen.winner));
 
         uint winningsClaimed = 0;
         uint totalWinnings = proxy.getClaimableWinnings(player.addr);
@@ -886,7 +886,7 @@ contract BettingTest is TestBaseContract {
 
         ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
         Wallet memory player = scen.players[1]; // 2nd and 4th players are winners
-        // assertEq(scen.betTargets[1], scen.winner);
+        assertEq(uint(scen.betTargets[1]), uint(scen.winner));
 
         uint winningsClaimed = 0;
         uint totalWinnings = proxy.getClaimableWinnings(player.addr);

--- a/test/BettingTest.sol
+++ b/test/BettingTest.sol
@@ -7,6 +7,7 @@ import { BoutNonMappingInfo, BoutFighter, BoutState } from "../src/Objects.sol";
 import { Wallet, TestBaseContract } from "./utils/TestBaseContract.sol";
 import { LibConstants } from "../src/libs/LibConstants.sol";
 import { LibTokenIds } from "../src/libs/LibToken.sol";
+import { LibBetting } from "../src/libs/LibBetting.sol";
 
 contract BettingTest is TestBaseContract {
     // ------------------------------------------------------ //
@@ -157,7 +158,7 @@ contract BettingTest is TestBaseContract {
     function testBetSingle() public returns (uint boutId) {
         boutId = 100;
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         // initialy no bouts
         assertEq(proxy.getTotalBouts(), 0, "no bouts at start");
@@ -205,7 +206,7 @@ contract BettingTest is TestBaseContract {
             scen.betAmounts[0],
             "bettor bet amount"
         );
-        assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
+        assertEq(proxy.getUserBoutsBetOn(player.addr), 1, "user supported bouts");
 
         // check MEME balances
         assertEq(memeToken.balanceOf(player.addr), 0, "MEME balance");
@@ -215,7 +216,7 @@ contract BettingTest is TestBaseContract {
     function testBetMultiple() public returns (uint boutId) {
         boutId = 100;
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         // place bets
         uint totalBetAmount = 0;
@@ -247,7 +248,7 @@ contract BettingTest is TestBaseContract {
                 scen.betAmounts[i],
                 "bettor bet amount"
             );
-            assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
+            assertEq(proxy.getUserBoutsBetOn(player.addr), 1, "user supported bouts");
         }
 
         // check MEME balances
@@ -279,7 +280,7 @@ contract BettingTest is TestBaseContract {
             bout.totalPot,
             "bettor bet amount"
         );
-        assertEq(proxy.getUserBoutsSupported(players[0].addr), 1, "user supported bouts");
+        assertEq(proxy.getUserBoutsBetOn(players[0].addr), 1, "user supported bouts");
 
         // check MEME balances
         assertEq(
@@ -322,7 +323,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutMustBeDoneByServer() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         address dummyServer = vm.addr(123);
 
@@ -355,7 +356,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutWithInvalidState() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         vm.startPrank(server.addr);
 
@@ -380,7 +381,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutWithInvalidWinner() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         vm.prank(server.addr);
         vm.expectRevert(
@@ -400,7 +401,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutWithPotMismatch() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
 
@@ -428,7 +429,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutWithInsufficientRevealValues() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         uint8[] memory badRevealValues = new uint8[](1);
 
@@ -448,7 +449,7 @@ contract BettingTest is TestBaseContract {
     function testEndBout() public returns (uint boutId) {
         boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         uint preEndedBouts = proxy.getEndedBouts();
 
@@ -502,7 +503,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutCreatesBoutIfNeeded() public {
         uint boutId = 100; // doesn't exist
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         uint preEndedBouts = proxy.getEndedBouts();
 
@@ -546,7 +547,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutEmitsEvent() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         vm.recordLogs();
 
@@ -572,7 +573,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutRevealsBetsCorrectly() public returns (uint boutId) {
         boutId = 100;
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         // place bets
         uint totalBetAmount = 0;
@@ -611,7 +612,7 @@ contract BettingTest is TestBaseContract {
     function testEndBoutAndRevealedBetForNonBettor() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         vm.prank(server.addr);
         proxy.endBout(
@@ -635,7 +636,7 @@ contract BettingTest is TestBaseContract {
     // ------------------------------------------------------ //
 
     function testProcessMultipleBoutsInSequence() public returns (uint[] memory boutIds) {
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         uint numBouts = 5;
 
@@ -720,7 +721,7 @@ contract BettingTest is TestBaseContract {
     }
 
     function testProcessMultipleBoutsInParallel() public returns (uint[] memory boutIds) {
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         uint numBouts = 5;
 
@@ -791,14 +792,14 @@ contract BettingTest is TestBaseContract {
 
     // ------------------------------------------------------ //
     //
-    // Claim winnings - successfully completed bouts
+    // Get Claimable winnings - successfully completed bouts
     //
     // ------------------------------------------------------ //
 
     function testGetClaimableWinningsBeforeBoutEnded() public {
         uint boutId = testBetMultiple();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         // check claimable winnings
         for (uint i = 0; i < scen.players.length; i++) {
@@ -820,7 +821,7 @@ contract BettingTest is TestBaseContract {
     function testGetClaimableWinningsForBoutWeDidNotBetIn() public {
         uint boutId = testEndBout();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         address playerAddr = vm.addr(666);
 
@@ -835,10 +836,7 @@ contract BettingTest is TestBaseContract {
     function testGetClaimableWinningsForSingleBout() public {
         uint boutId = testEndBout();
 
-        BettingScenario memory scen = _getScenario1();
-
-        console.log(scen.revealValues[0]);
-        console.log(scen.revealValues[1]);
+        BettingScenario memory scen = _getScenario_Default();
 
         // check claimable winnings
         for (uint i = 0; i < scen.players.length; i++) {
@@ -853,7 +851,7 @@ contract BettingTest is TestBaseContract {
     function testGetClaimableWinningsForMultipleBouts() public {
         uint[] memory boutIds = testProcessMultipleBoutsInParallel();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         // check claimable winnings
         for (uint i = 1; i < 2; i++) {
@@ -864,6 +862,72 @@ contract BettingTest is TestBaseContract {
             assertEq(winnings, scen.expectedWinnings[i] * boutIds.length, "winnings");
         }
     }
+
+    function testGetClaimableWinningsWhenAllBetsAreOnLoser() public {
+        BettingScenario memory scen = _getScenario_AllOnLoser();
+
+        uint boutId = 100;
+
+        for (uint j = 0; j < scen.players.length; j += 1) {
+            _bet(scen.players[j].addr, boutId, scen.betValues[j], scen.betAmounts[j]);
+        }
+
+        vm.prank(server.addr);
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
+
+        // check claimable winnings
+        for (uint i = 0; i < scen.players.length; i++) {
+            Wallet memory player = scen.players[i];
+
+            uint winnings = proxy.getClaimableWinnings(player.addr);
+
+            assertEq(winnings, scen.expectedWinnings[i], "winnings");
+        }
+    }
+
+    function testGetClaimableWinningsWhenAllBetsAreOnWinner() public {
+        BettingScenario memory scen = _getScenario_AllOnWinner();
+
+        uint boutId = 100;
+
+        for (uint j = 0; j < scen.players.length; j += 1) {
+            _bet(scen.players[j].addr, boutId, scen.betValues[j], scen.betAmounts[j]);
+        }
+
+        vm.prank(server.addr);
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
+
+        // check claimable winnings
+        for (uint i = 0; i < scen.players.length; i++) {
+            Wallet memory player = scen.players[i];
+
+            uint winnings = proxy.getClaimableWinnings(player.addr);
+
+            assertEq(winnings, scen.expectedWinnings[i], "winnings");
+        }
+    }
+
+    // ------------------------------------------------------ //
+    //
+    //  Claim winnings - successfully completed bouts
+    //
+    // ------------------------------------------------------ //
 
     // use this to avoid stack too deep errors
     struct ClaimWinningsLoopValues {
@@ -880,7 +944,7 @@ contract BettingTest is TestBaseContract {
     function testClaimWinningsForSingleBout() public {
         uint boutId = testEndBout();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         ClaimWinningsLoopValues memory v;
         Wallet memory player;
@@ -936,7 +1000,7 @@ contract BettingTest is TestBaseContract {
     function testClaimWinningsForMultipleBouts() public {
         uint[] memory boutIds = testProcessMultipleBoutsInParallel();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
         Wallet memory player = scen.players[2];
@@ -1003,7 +1067,7 @@ contract BettingTest is TestBaseContract {
     function testClaimWinningsForMultipleBoutsSubset() public {
         uint[] memory boutIds = testProcessMultipleBoutsInParallel();
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         ClaimWinningsLoopValues[] memory v = new ClaimWinningsLoopValues[](boutIds.length);
         Wallet memory player = scen.players[2];
@@ -1080,15 +1144,15 @@ contract BettingTest is TestBaseContract {
     //
     // ------------------------------------------------------ //
 
-    function testEndBoutWhenExpired() public returns (uint boutId) {
-        boutId = testBetMultiple();
+    function testEndBoutWhenExpired() public {
+        uint boutId = testBetMultiple();
 
         uint expiryTime = proxy.getBoutNonMappingInfo(boutId).expiryTime;
 
         // move to past expiry
         vm.warp(expiryTime);
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         vm.prank(server.addr);
         vm.expectRevert(abi.encodeWithSelector(BoutExpiredError.selector, boutId, expiryTime));
@@ -1103,15 +1167,15 @@ contract BettingTest is TestBaseContract {
         );
     }
 
-    function testGetClaimableWinningsForExpiredBout() public returns (uint boutId) {
-        boutId = testBetMultiple();
+    function testGetClaimableWinningsForExpiredBout() public {
+        uint boutId = testBetMultiple();
 
         uint expiryTime = proxy.getBoutNonMappingInfo(boutId).expiryTime;
 
         // move to past expiry
         vm.warp(expiryTime);
 
-        BettingScenario memory scen = _getScenario1();
+        BettingScenario memory scen = _getScenario_Default();
 
         // check claimable winnings
         for (uint i = 0; i < scen.players.length; i++) {
@@ -1148,19 +1212,18 @@ contract BettingTest is TestBaseContract {
         );
     }
 
-    function testClaimWinningsForExpiredBout() public returns (uint boutId) {
-        boutId = testBetMultiple();
+    function testClaimWinningsForExpiredBout() public {
+        uint boutId = testBetMultiple();
 
         uint expiryTime = proxy.getBoutNonMappingInfo(boutId).expiryTime;
 
         // move to past expiry
         vm.warp(expiryTime);
 
-        BettingScenario memory scen = _getScenario1();
-        BoutFighter f1 = BoutFighter.FighterA;
-        BoutFighter f2 = BoutFighter.FighterB;
+        BettingScenario memory scen = _getScenario_Default();
 
-        Wallet memory player = scen.players[1]; // 2nd and 4th players are winners
+        Wallet memory player = scen.players[2];
+        assertEq(scen.betTargets[2], scen.winner, "bet target");
 
         uint totalWinnings = proxy.getClaimableWinnings(player.addr);
         uint proxyMemeTokenBalance = memeToken.balanceOf(proxyAddress);
@@ -1206,6 +1269,88 @@ contract BettingTest is TestBaseContract {
         );
     }
 
+    function testClaimWinningsForExpiredAndEndedBouts() public {
+        BettingScenario memory scen = _getScenario_Default();
+
+        uint numBouts = 5;
+
+        uint[] memory boutIds = new uint[](numBouts);
+
+        for (uint i = 0; i < numBouts; i += 1) {
+            boutIds[i] = 100 + i;
+
+            for (uint j = 0; j < scen.players.length; j += 1) {
+                _bet(scen.players[j].addr, boutIds[i], scen.betValues[j], scen.betAmounts[j]);
+            }
+
+            proxy._testSetBoutExpiryTime(boutIds[i], block.timestamp + 100 * (i + 1));
+        }
+
+        // move past expiry of 1st bout
+        vm.warp(block.timestamp + 100);
+
+        // end the 3rd bout
+        vm.prank(server.addr);
+        proxy.endBout(
+            boutIds[2],
+            21,
+            23,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
+
+        // at this point, bouts 2, 4, and 5 have yet to be ended
+
+        Wallet memory player = scen.players[2];
+        assertEq(scen.betTargets[2], scen.winner, "bet target");
+
+        uint totalWinnings = proxy.getClaimableWinnings(player.addr);
+        uint proxyMemeTokenBalance = memeToken.balanceOf(proxyAddress);
+        ClaimWinningsLoopValues memory v;
+
+        // make claim
+        proxy.claimWinnings(player.addr, 10);
+
+        // check bout winnings claimed status
+        assertEq(proxy.getBoutWinningsClaimed(boutIds[0], player.addr), true, "bout 1 claimed");
+        assertEq(
+            proxy.getBoutWinningsClaimed(boutIds[1], player.addr),
+            false,
+            "bout 2 not claimed"
+        );
+        assertEq(proxy.getBoutWinningsClaimed(boutIds[2], player.addr), true, "bout 3 claimed");
+        assertEq(
+            proxy.getBoutWinningsClaimed(boutIds[3], player.addr),
+            false,
+            "bout 4 not claimed"
+        );
+        assertEq(
+            proxy.getBoutWinningsClaimed(boutIds[4], player.addr),
+            false,
+            "bout 5 not claimed"
+        );
+
+        // check that tokens were transferred
+        assertEq(memeToken.balanceOf(player.addr), totalWinnings, "total winnings");
+        assertEq(
+            memeToken.balanceOf(proxyAddress),
+            proxyMemeTokenBalance - totalWinnings,
+            "proxy meme token balance"
+        );
+
+        // check that there no more winnings to claim for this player
+        assertEq(proxy.getClaimableWinnings(player.addr), 0, "all winnings claimed");
+
+        // check that user bout winningsToClaim list is now of length 3
+        assertEq(
+            proxy._testGetUserWinningsToClaimListLength(player.addr),
+            3,
+            "winnings to claim length"
+        );
+    }
+
     // ------------------------------------------------------ //
     //
     // Private/internal methods
@@ -1244,8 +1389,60 @@ contract BettingTest is TestBaseContract {
         uint[] expectedWinnings;
     }
 
-    function _getScenario1() internal returns (BettingScenario memory scen) {
+    // 5 players, 3 bet on the loser, 2 on the winner
+    function _getScenario_Default() internal returns (BettingScenario memory scen) {
         uint LEN = 5;
+
+        scen.winner = BoutFighter.FighterB;
+        scen.loser = BoutFighter.FighterA;
+        scen.betTargets = new BoutFighter[](LEN);
+        for (uint i = 0; i < LEN; i++) {
+            scen.betTargets[i] = (i == 0 || i == 1 || i == 4) ? scen.loser : scen.winner;
+        }
+
+        scen = __buildScenario(scen);
+    }
+
+    // 5 players, all bet on the loser
+    function _getScenario_AllOnLoser() internal returns (BettingScenario memory scen) {
+        uint LEN = 5;
+
+        scen.winner = BoutFighter.FighterB;
+        scen.loser = BoutFighter.FighterA;
+        scen.betTargets = new BoutFighter[](LEN);
+        for (uint i = 0; i < LEN; i++) {
+            scen.betTargets[i] = scen.loser;
+        }
+
+        scen = __buildScenario(scen);
+
+        for (uint i = 0; i < LEN; i++) {
+            assertEq(scen.expectedWinnings[i], 0, "expected winnings is 0");
+        }
+    }
+
+    // 5 players, all bet on the winner
+    function _getScenario_AllOnWinner() internal returns (BettingScenario memory scen) {
+        uint LEN = 5;
+
+        scen.winner = BoutFighter.FighterB;
+        scen.loser = BoutFighter.FighterA;
+        scen.betTargets = new BoutFighter[](LEN);
+        for (uint i = 0; i < LEN; i++) {
+            scen.betTargets[i] = scen.winner;
+        }
+
+        scen = __buildScenario(scen);
+
+        for (uint i = 0; i < LEN; i++) {
+            assertEq(scen.expectedWinnings[i], scen.betAmounts[i], "expected winnings same as bet");
+        }
+    }
+
+    function __buildScenario(
+        BettingScenario memory scen
+    ) internal returns (BettingScenario memory) {
+        uint LEN = scen.betTargets.length;
 
         scen.players = new Wallet[](LEN);
 
@@ -1255,14 +1452,7 @@ contract BettingTest is TestBaseContract {
 
         scen.betAmounts = new uint[](LEN);
         scen.betValues = new uint8[](LEN);
-        scen.revealValues = new uint8[]((LEN + 3) >> 2); // 4 bets per uint8
-
-        scen.winner = BoutFighter.FighterB;
-        scen.loser = BoutFighter.FighterA;
-        scen.betTargets = new BoutFighter[](LEN);
-        for (uint i = 0; i < LEN; i++) {
-            scen.betTargets[i] = (i == 0 || i == 1 || i == 4) ? scen.loser : scen.winner;
-        }
+        scen.revealValues = new uint8[](LibBetting.calculateNumRevealValues(LEN));
 
         uint winningPot;
         uint losingPot;
@@ -1309,5 +1499,7 @@ contract BettingTest is TestBaseContract {
                     ((((scen.betAmounts[i] * 1000 ether) / winningPot) * losingPot) / 1000 ether);
             }
         }
+
+        return scen;
     }
 }

--- a/test/BettingTest.sol
+++ b/test/BettingTest.sol
@@ -26,17 +26,32 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(
+            server.addr,
+            account0,
+            boutId,
+            1,
+            LibConstants.MIN_BET_AMOUNT,
+            block.timestamp + 1000
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
-        // state: Ended
+        // state: Ended - should fail
         proxy._testSetBoutState(boutId, BoutState.Ended);
-        vm.expectRevert(abi.encodePacked(BoutInWrongStateError.selector, uint(100), uint256(BoutState.Ended)));
+        vm.expectRevert(
+            abi.encodePacked(BoutInWrongStateError.selector, uint(100), uint256(BoutState.Ended))
+        );
         proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
 
-        // state: Cancelled
+        // state: Cancelled - should fail
         proxy._testSetBoutState(boutId, BoutState.Cancelled);
-        vm.expectRevert(abi.encodePacked(BoutInWrongStateError.selector, uint(100), uint256(BoutState.Cancelled)));
+        vm.expectRevert(
+            abi.encodePacked(
+                BoutInWrongStateError.selector,
+                uint(100),
+                uint256(BoutState.Cancelled)
+            )
+        );
         proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
     }
 
@@ -45,7 +60,14 @@ contract BettingTest is TestBaseContract {
 
         // do signature
         address signer = vm.addr(123);
-        bytes32 digest = proxy.calculateBetSignature(signer, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(
+            signer,
+            account0,
+            boutId,
+            1,
+            LibConstants.MIN_BET_AMOUNT,
+            block.timestamp + 1000
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(123, digest);
 
         vm.expectRevert(SignerMustBeServerError.selector);
@@ -56,7 +78,14 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp - 1);
+        bytes32 digest = proxy.calculateBetSignature(
+            server.addr,
+            account0,
+            boutId,
+            1,
+            LibConstants.MIN_BET_AMOUNT,
+            block.timestamp - 1
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
         vm.expectRevert(SignatureExpiredError.selector);
@@ -67,10 +96,24 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT - 1, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(
+            server.addr,
+            account0,
+            boutId,
+            1,
+            LibConstants.MIN_BET_AMOUNT - 1,
+            block.timestamp + 1000
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
-        vm.expectRevert(abi.encodeWithSelector(MinimumBetAmountError.selector, uint(boutId), address(this), LibConstants.MIN_BET_AMOUNT - 1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MinimumBetAmountError.selector,
+                uint(boutId),
+                address(this),
+                LibConstants.MIN_BET_AMOUNT - 1
+            )
+        );
         proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT - 1, block.timestamp + 1000, v, r, s);
     }
 
@@ -80,10 +123,19 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, br, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(
+            server.addr,
+            account0,
+            boutId,
+            br,
+            LibConstants.MIN_BET_AMOUNT,
+            block.timestamp + 1000
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidBetTargetError.selector, boutId, address(this), br));
+        vm.expectRevert(
+            abi.encodeWithSelector(InvalidBetTargetError.selector, boutId, address(this), br)
+        );
         proxy.bet(boutId, br, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
     }
 
@@ -91,12 +143,25 @@ contract BettingTest is TestBaseContract {
         uint boutId = 100;
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, account0, boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(
+            server.addr,
+            account0,
+            boutId,
+            1,
+            LibConstants.MIN_BET_AMOUNT,
+            block.timestamp + 1000
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
         uint256 userBalance = proxy.tokenBalanceOf(LibTokenIds.TOKEN_MEME, address(this));
 
-        vm.expectRevert(abi.encodeWithSelector(TokenBalanceInsufficient.selector, userBalance, LibConstants.MIN_BET_AMOUNT));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TokenBalanceInsufficient.selector,
+                userBalance,
+                LibConstants.MIN_BET_AMOUNT
+            )
+        );
         proxy.bet(boutId, 1, LibConstants.MIN_BET_AMOUNT, block.timestamp + 1000, v, r, s);
     }
 
@@ -126,13 +191,25 @@ contract BettingTest is TestBaseContract {
 
         assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), 0, "fighter A pot");
         assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), 0, "fighter B pot");
-        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA), 0, "fighter A pot balance");
-        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB), 0, "fighter B pot balance");
+        assertEq(
+            proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA),
+            0,
+            "fighter A pot balance"
+        );
+        assertEq(
+            proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB),
+            0,
+            "fighter B pot balance"
+        );
 
         // check player data
         assertEq(proxy.getBoutSupporter(boutId, 1), player.addr, "bettor address");
         assertEq(proxy.getBoutHiddenBet(boutId, player.addr), 1, "bettor hidden bet");
-        assertEq(proxy.getBoutBetAmount(boutId, player.addr), scen.betAmounts[0], "bettor bet amount");
+        assertEq(
+            proxy.getBoutBetAmount(boutId, player.addr),
+            scen.betAmounts[0],
+            "bettor bet amount"
+        );
         assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
 
         // check MEME balances
@@ -140,7 +217,7 @@ contract BettingTest is TestBaseContract {
         assertEq(memeToken.balanceOf(address(proxy)), bout.totalPot, "MEME balance");
     }
 
-    function testBetMultipleSucceeds() public returns (uint boutId) {
+    function testBetMultipleUpdatesState() public returns (uint boutId) {
         boutId = 100;
 
         BettingScenario memory scen = _getScenario1();
@@ -152,6 +229,8 @@ contract BettingTest is TestBaseContract {
             totalBetAmount += scen.betAmounts[i];
             _bet(player.addr, boutId, 1, scen.betAmounts[i]);
         }
+
+        assertEq(totalBetAmount, scen.fighterAPot + scen.fighterBPot, "check total bet amount");
 
         // check total bouts
         assertEq(proxy.getTotalBouts(), 1, "still only 1 bout created");
@@ -168,7 +247,11 @@ contract BettingTest is TestBaseContract {
 
             assertEq(proxy.getBoutSupporter(boutId, i + 1), player.addr, "bettor address");
             assertEq(proxy.getBoutHiddenBet(boutId, player.addr), 1, "bettor hidden bet");
-            assertEq(proxy.getBoutBetAmount(boutId, player.addr), scen.betAmounts[i], "bettor bet amount");
+            assertEq(
+                proxy.getBoutBetAmount(boutId, player.addr),
+                scen.betAmounts[i],
+                "bettor bet amount"
+            );
             assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
         }
 
@@ -200,7 +283,11 @@ contract BettingTest is TestBaseContract {
         assertEq(proxy.getUserBoutsSupported(player1.addr), 1, "user supported bouts");
 
         // check MEME balances
-        assertEq(memeToken.balanceOf(player1.addr), LibConstants.MIN_BET_AMOUNT * 10, "MEME balance");
+        assertEq(
+            memeToken.balanceOf(player1.addr),
+            LibConstants.MIN_BET_AMOUNT * 10,
+            "MEME balance"
+        );
         assertEq(memeToken.balanceOf(address(proxy)), bout.totalPot, "MEME balance");
     }
 
@@ -217,7 +304,11 @@ contract BettingTest is TestBaseContract {
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries.length, 3, "Invalid entry count");
         assertEq(entries[2].topics.length, 1, "Invalid event count");
-        assertEq(entries[2].topics[0], keccak256("BetPlaced(uint256,address)"), "Invalid event signature");
+        assertEq(
+            entries[2].topics[0],
+            keccak256("BetPlaced(uint256,address)"),
+            "Invalid event signature"
+        );
         (uint eBoutId, address bettor) = abi.decode(entries[2].data, (uint256, address));
         assertEq(eBoutId, boutId, "boutId incorrect");
         assertEq(bettor, player1.addr, "bettor incorrect");
@@ -230,7 +321,6 @@ contract BettingTest is TestBaseContract {
     // ------------------------------------------------------ //
 
     function testEndBoutMustBeDoneByServer() public {
-        // create bout, place bets, reveal bets
         uint boutId = _setupBoutWithBets();
 
         BettingScenario memory scen = _getScenario1();
@@ -239,67 +329,76 @@ contract BettingTest is TestBaseContract {
 
         vm.prank(dummyServer);
         vm.expectRevert(CallerMustBeServerError.selector);
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, scen.winner, scen.revealValues);
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
 
         proxy.setAddress(LibConstants.SERVER_ADDRESS, dummyServer);
 
         vm.prank(dummyServer);
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, scen.winner, scen.revealValues);
-    }
-
-    function testEndBoutEmitsEvent() public {
-        // create bout, place bets, reveal bets
-        uint boutId = _setupBoutWithBets();
-
-        BettingScenario memory scen = _getScenario1();
-
-        vm.recordLogs();
-
-        vm.prank(server.addr);
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, scen.winner, scen.revealValues);
-
-        // check logs
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries[0].topics.length, 1, "Invalid event count");
-        assertEq(entries[0].topics[0], keccak256("BoutEnded(uint256)"));
-        uint eBoutId = abi.decode(entries[0].data, (uint));
-        assertEq(eBoutId, boutId, "boutId incorrect");
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
     }
 
     function testEndBoutWithInvalidState() public {
-        // create bout, place bets, reveal bets
         uint boutId = _setupBoutWithBets();
 
         BettingScenario memory scen = _getScenario1();
 
         vm.startPrank(server.addr);
 
-        // state: Unknown
-        proxy._testSetBoutState(boutId, BoutState.Uninitialized);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Uninitialized));
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, scen.winner, scen.revealValues);
-
-        // state: Ended
+        // state: Ended - fails
         proxy._testSetBoutState(boutId, BoutState.Ended);
-        vm.expectRevert(abi.encodeWithSelector(BoutInWrongStateError.selector, 1, BoutState.Ended));
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, scen.winner, scen.revealValues);
+        vm.expectRevert(
+            abi.encodeWithSelector(BoutInWrongStateError.selector, boutId, BoutState.Ended)
+        );
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
 
         vm.stopPrank();
     }
 
     function testEndBoutWithInvalidWinner() public {
-        // create bout, place bets, reveal bets
         uint boutId = _setupBoutWithBets();
 
         BettingScenario memory scen = _getScenario1();
 
         vm.prank(server.addr);
-        vm.expectRevert(abi.encodeWithSelector(InvalidWinnerError.selector, 1, BoutFighter.Uninitialized));
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, BoutFighter.Uninitialized, scen.revealValues);
+        vm.expectRevert(
+            abi.encodeWithSelector(InvalidWinnerError.selector, boutId, BoutFighter.Uninitialized)
+        );
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            BoutFighter.Uninitialized,
+            scen.revealValues
+        );
     }
 
     function testEndBoutWithPotMismatch() public {
-        // create bout, place bets, reveal bets
         uint boutId = _setupBoutWithBets();
 
         BettingScenario memory scen = _getScenario1();
@@ -307,12 +406,27 @@ contract BettingTest is TestBaseContract {
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
 
         vm.prank(server.addr);
-        vm.expectRevert(abi.encodeWithSelector(PotMismatchError.selector, scen.fighterAPot - 1, scen.fighterBPot, bout.totalPot));
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot - 1, scen.fighterBPot, scen.winner, scen.revealValues);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PotMismatchError.selector,
+                boutId,
+                scen.fighterAPot - 1,
+                scen.fighterBPot,
+                bout.totalPot
+            )
+        );
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot - 1,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
     }
 
     function testEndBoutUpdatesState() public returns (uint boutId) {
-        // create bout, place bets, reveal bets
         boutId = _setupBoutWithBets();
 
         BettingScenario memory scen = _getScenario1();
@@ -320,7 +434,15 @@ contract BettingTest is TestBaseContract {
         uint preEndedBouts = proxy.getEndedBouts();
 
         vm.prank(server.addr);
-        proxy.endBout(boutId, 21, 22, scen.fighterAPot, scen.fighterBPot, scen.winner, scen.revealValues);
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
 
         // check the state
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
@@ -332,14 +454,100 @@ contract BettingTest is TestBaseContract {
         assertEq(bout.revealValues, scen.revealValues, "reveal values");
 
         assertEq(proxy.getBoutFighterId(boutId, BoutFighter.FighterA), 21, "fighter A id");
-        assertEq(proxy.getBoutFighterId(boutId, BoutFighter.FighterA), 22, "fighter B id");
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), scen.fighterAPot, "fighter A pot");
-        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), scen.fighterBPot, "fighter B pot");
-        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA), scen.fighterAPot, "fighter A pot balance");
-        assertEq(proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB), scen.fighterBPot, "fighter B pot balance");
+        assertEq(proxy.getBoutFighterId(boutId, BoutFighter.FighterB), 22, "fighter B id");
+        assertEq(
+            proxy.getBoutFighterPot(boutId, BoutFighter.FighterA),
+            scen.fighterAPot,
+            "fighter A pot"
+        );
+        assertEq(
+            proxy.getBoutFighterPot(boutId, BoutFighter.FighterB),
+            scen.fighterBPot,
+            "fighter B pot"
+        );
+        assertEq(
+            proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA),
+            scen.fighterAPot,
+            "fighter A pot balance"
+        );
+        assertEq(
+            proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB),
+            scen.fighterBPot,
+            "fighter B pot balance"
+        );
 
         // check global state
         assertEq(proxy.getEndedBouts(), preEndedBouts + 1, "ended bouts");
+    }
+
+    function testEndBoutCreatesBoutIfNeeded() public {
+        uint boutId = 100; // doesn't exist
+
+        BettingScenario memory scen = _getScenario1();
+
+        uint preEndedBouts = proxy.getEndedBouts();
+
+        uint8[] memory emptyRevealValues;
+
+        vm.prank(server.addr);
+        proxy.endBout(boutId, 21, 22, 0, 0, scen.winner, emptyRevealValues);
+
+        // check total bouts
+        assertEq(proxy.getTotalBouts(), 1, "total bouts");
+        assertEq(proxy.getBoutIdByIndex(1), boutId, "bout id by index");
+
+        // check bout state
+        BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutId);
+        assertEq(bout.state, BoutState.Ended, "state");
+        assertGt(bout.endTime, 0, "end time");
+        assertEq(bout.totalPot, 0, "total pot");
+        assertEq(bout.revealValues, emptyRevealValues, "reveal values");
+        assertEq(bout.winner, scen.winner, "winner");
+        assertEq(bout.loser, scen.loser, "loser");
+
+        assertEq(proxy.getBoutFighterId(boutId, BoutFighter.FighterA), 21, "fighter A id");
+        assertEq(proxy.getBoutFighterId(boutId, BoutFighter.FighterB), 22, "fighter B id");
+        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterA), 0, "fighter A pot");
+        assertEq(proxy.getBoutFighterPot(boutId, BoutFighter.FighterB), 0, "fighter B pot");
+        assertEq(
+            proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterA),
+            0,
+            "fighter A pot balance"
+        );
+        assertEq(
+            proxy.getBoutFighterPotBalance(boutId, BoutFighter.FighterB),
+            0,
+            "fighter B pot balance"
+        );
+
+        // check global state
+        assertEq(proxy.getEndedBouts(), preEndedBouts + 1, "ended bouts");
+    }
+
+    function testEndBoutEmitsEvent() public {
+        uint boutId = _setupBoutWithBets();
+
+        BettingScenario memory scen = _getScenario1();
+
+        vm.recordLogs();
+
+        vm.prank(server.addr);
+        proxy.endBout(
+            boutId,
+            21,
+            22,
+            scen.fighterAPot,
+            scen.fighterBPot,
+            scen.winner,
+            scen.revealValues
+        );
+
+        // check logs
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries[0].topics.length, 1, "Invalid event count");
+        assertEq(entries[0].topics[0], keccak256("BoutEnded(uint256)"));
+        uint eBoutId = abi.decode(entries[0].data, (uint));
+        assertEq(eBoutId, boutId, "boutId incorrect");
     }
 
     // ------------------------------------------------------ //
@@ -349,7 +557,7 @@ contract BettingTest is TestBaseContract {
     // ------------------------------------------------------ //
 
     function _setupBoutWithBets() internal returns (uint) {
-        return testBetUpdatesState();
+        return testBetMultipleUpdatesState();
     }
 
     function _bet(address bettor, uint boutId, uint8 br, uint amount) internal {
@@ -357,7 +565,14 @@ contract BettingTest is TestBaseContract {
         proxy._testMintMeme(bettor, amount);
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, bettor, boutId, br, amount, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(
+            server.addr,
+            bettor,
+            boutId,
+            br,
+            amount,
+            block.timestamp + 1000
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
         vm.prank(bettor);
@@ -426,9 +641,13 @@ contract BettingTest is TestBaseContract {
 
         scen.expectedWinnings = new uint[](5);
         scen.expectedWinnings[0] = 0;
-        scen.expectedWinnings[1] = scen.betAmounts[1] + ((((scen.betAmounts[1] * 1000 ether) / winningPot) * losingPot) / 1000 ether);
+        scen.expectedWinnings[1] =
+            scen.betAmounts[1] +
+            ((((scen.betAmounts[1] * 1000 ether) / winningPot) * losingPot) / 1000 ether);
         scen.expectedWinnings[2] = 0;
-        scen.expectedWinnings[3] = scen.betAmounts[3] + ((((scen.betAmounts[3] * 1000 ether) / winningPot) * losingPot) / 1000 ether);
+        scen.expectedWinnings[3] =
+            scen.betAmounts[3] +
+            ((((scen.betAmounts[3] * 1000 ether) / winningPot) * losingPot) / 1000 ether);
         scen.expectedWinnings[4] = 0;
     }
 }

--- a/test/BettingTest.sol.bak
+++ b/test/BettingTest.sol.bak
@@ -178,16 +178,16 @@ contract BettingTest is TestBaseContract {
         // check bout basic state
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutNum);
         assertEq(uint(bout.state), uint(BoutState.Created), "created");
-        assertEq(bout.numSupporters, 5, "no. of supporters");
+        assertEq(bout.numSupporters, 5, "no. of bettors");
         assertEq(bout.totalPot, LibConstants.MIN_BET_AMOUNT * 15, "total pot");
 
-        // check supporter data
+        // check bettor data
         for (uint i = 1; i <= players.length; i += 1) {
             Wallet memory player = players[i - 1];
 
-            assertEq(proxy.getBoutSupporter(boutNum, i), player.addr, "supporter address");
-            assertEq(proxy.getBoutHiddenBet(boutNum, player.addr), 1, "supporter hidden bet");
-            assertEq(proxy.getBoutBetAmount(boutNum, player.addr), betAmounts[i - 1], "supporter bet amount");
+            assertEq(proxy.getBoutSupporter(boutNum, i), player.addr, "bettor address");
+            assertEq(proxy.getBoutHiddenBet(boutNum, player.addr), 1, "bettor hidden bet");
+            assertEq(proxy.getBoutBetAmount(boutNum, player.addr), betAmounts[i - 1], "bettor bet amount");
 
             assertEq(proxy.getUserBoutsSupported(player.addr), 1, "user supported bouts");
         }
@@ -211,13 +211,13 @@ contract BettingTest is TestBaseContract {
         // check bout basic state
         BoutNonMappingInfo memory bout = proxy.getBoutNonMappingInfo(boutNum);
         assertEq(uint(bout.state), uint(BoutState.Created), "created");
-        assertEq(bout.numSupporters, 1, "no. of supporters");
+        assertEq(bout.numSupporters, 1, "no. of bettors");
         assertEq(bout.totalPot, LibConstants.MIN_BET_AMOUNT * 5, "total pot");
 
-        // check supporter data
-        assertEq(proxy.getBoutSupporter(boutNum, 1), player1.addr, "supporter address");
-        assertEq(proxy.getBoutHiddenBet(boutNum, player1.addr), 1, "supporter hidden bet");
-        assertEq(proxy.getBoutBetAmount(boutNum, player1.addr), bout.totalPot, "supporter bet amount");
+        // check bettor data
+        assertEq(proxy.getBoutSupporter(boutNum, 1), player1.addr, "bettor address");
+        assertEq(proxy.getBoutHiddenBet(boutNum, player1.addr), 1, "bettor hidden bet");
+        assertEq(proxy.getBoutBetAmount(boutNum, player1.addr), bout.totalPot, "bettor bet amount");
         assertEq(proxy.getUserBoutsSupported(player1.addr), boutNum, "user supported bouts");
 
         // check MEME balances
@@ -240,9 +240,9 @@ contract BettingTest is TestBaseContract {
         assertEq(entries.length, 3, "Invalid entry count");
         assertEq(entries[2].topics.length, 1, "Invalid event count");
         assertEq(entries[2].topics[0], keccak256("BetPlaced(uint256,address)"), "Invalid event signature");
-        (uint eBoutNum, address supporter) = abi.decode(entries[2].data, (uint256, address));
+        (uint eBoutNum, address bettor) = abi.decode(entries[2].data, (uint256, address));
         assertEq(eBoutNum, boutNum, "boutNum incorrect");
-        assertEq(supporter, player1.addr, "supporter incorrect");
+        assertEq(bettor, player1.addr, "bettor incorrect");
     }
 
     // ------------------------------------------------------ //
@@ -805,15 +805,15 @@ contract BettingTest is TestBaseContract {
     //
     // ------------------------------------------------------ //
 
-    function _bet(address supporter, uint boutNum, uint8 br, uint amount) internal {
+    function _bet(address bettor, uint boutNum, uint8 br, uint amount) internal {
         // mint tokens
-        proxy._testMintMeme(supporter, amount);
+        proxy._testMintMeme(bettor, amount);
 
         // do signature
-        bytes32 digest = proxy.calculateBetSignature(server.addr, supporter, boutNum, br, amount, block.timestamp + 1000);
+        bytes32 digest = proxy.calculateBetSignature(server.addr, bettor, boutNum, br, amount, block.timestamp + 1000);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(server.privateKey, digest);
 
-        vm.prank(supporter);
+        vm.prank(bettor);
         proxy.bet(boutNum, br, amount, block.timestamp + 1000, v, r, s);
     }
 

--- a/test/ItemsTest.sol
+++ b/test/ItemsTest.sol
@@ -5,7 +5,8 @@ import "forge-std/Test.sol";
 import "src/Errors.sol";
 import { BoutNonMappingInfo, BoutFighter, BoutState, MemeBuySizeDollars } from "src/Objects.sol";
 import { Wallet, TestBaseContract } from "./utils/TestBaseContract.sol";
-import { LibConstants, LibTokenIds } from "src/libs/LibConstants.sol";
+import { LibConstants } from "src/libs/LibConstants.sol";
+import { LibTokenIds } from "src/libs/LibToken.sol";
 import { IERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 /// @notice These tests first fork polygon mainnet.

--- a/test/MemeTest.sol
+++ b/test/MemeTest.sol
@@ -39,7 +39,12 @@ contract MemeTest is TestBaseContract {
 
     function testPurchaseMeme() public {
         proxy.setAddress(LibConstants.TREASURY_ADDRESS, address(proxy));
-        writeTokenBalance(address(this), address(proxy), LibConstants.WMATIC_POLYGON_ADDRESS, 10000e18);
+        writeTokenBalance(
+            address(this),
+            address(proxy),
+            LibConstants.WMATIC_POLYGON_ADDRESS,
+            10000e18
+        );
 
         IERC20 wmatic = IERC20(LibConstants.WMATIC_POLYGON_ADDRESS);
 
@@ -67,31 +72,31 @@ contract MemeTest is TestBaseContract {
     // ------------------------------------------------------ //
 
     function testClaimMemeGivesUptoMinBetAmount() public {
-        assertEq(memeToken.balanceOf(player1.addr), 0);
+        assertEq(memeToken.balanceOf(players[0].addr), 0);
 
-        vm.prank(player1.addr);
+        vm.prank(players[0].addr);
         proxy.claimFreeMeme();
 
-        assertEq(memeToken.balanceOf(player1.addr), LibConstants.MIN_BET_AMOUNT);
+        assertEq(memeToken.balanceOf(players[0].addr), LibConstants.MIN_BET_AMOUNT);
 
         uint amt = LibConstants.MIN_BET_AMOUNT / 3;
-        proxy._testMintMeme(player2.addr, amt);
-        assertEq(memeToken.balanceOf(player2.addr), amt);
+        proxy._testMintMeme(players[1].addr, amt);
+        assertEq(memeToken.balanceOf(players[1].addr), amt);
 
-        vm.prank(player2.addr);
+        vm.prank(players[1].addr);
         proxy.claimFreeMeme();
 
-        assertEq(memeToken.balanceOf(player2.addr), LibConstants.MIN_BET_AMOUNT);
+        assertEq(memeToken.balanceOf(players[1].addr), LibConstants.MIN_BET_AMOUNT);
     }
 
     function testClaimMemeDoesNothingIfBalanceAlreadyEnough() public {
         uint amt = LibConstants.MIN_BET_AMOUNT;
-        proxy._testMintMeme(player1.addr, amt);
-        assertEq(memeToken.balanceOf(player1.addr), amt);
+        proxy._testMintMeme(players[0].addr, amt);
+        assertEq(memeToken.balanceOf(players[0].addr), amt);
 
-        vm.prank(player1.addr);
+        vm.prank(players[0].addr);
         proxy.claimFreeMeme();
 
-        assertEq(memeToken.balanceOf(player1.addr), amt);
+        assertEq(memeToken.balanceOf(players[0].addr), amt);
     }
 }

--- a/test/utils/TestBaseContract.sol
+++ b/test/utils/TestBaseContract.sol
@@ -9,6 +9,7 @@ import { LibConstants } from "../../src/libs/LibConstants.sol";
 import { LibGeneratedFacetHelpers } from "../../script/generated/LibGeneratedFacetHelpers.sol";
 import { MemeToken } from "../../src/MemeToken.sol";
 import { ITestFacet, LibTestFacetsHelper } from "./TestFacets.sol";
+import { BoutState, BoutFighter } from "../../src/Objects.sol";
 
 struct Wallet {
     address addr;
@@ -72,5 +73,26 @@ contract TestBaseContract is Test {
 
         // set ownership
         proxy.transferOwnership(account0);
+    }
+
+    // ------------------------------------------------------ //
+    //
+    // Custom assertions
+    //
+    // ------------------------------------------------------ //
+
+    function assertEq(uint8[] memory a, uint8[] memory b, string memory err) internal {
+        assertEq(a.length, b.length, err);
+        for (uint i = 0; i < a.length; i++) {
+            assertEq(a[i], b[i], err);
+        }
+    }
+
+    function assertEq(BoutState a, BoutState b, string memory err) internal {
+        assertEq(uint(a), uint(b), err);
+    }
+
+    function assertEq(BoutFighter a, BoutFighter b, string memory err) internal {
+        assertEq(uint(a), uint(b), err);
     }
 }

--- a/test/utils/TestBaseContract.sol
+++ b/test/utils/TestBaseContract.sol
@@ -25,18 +25,16 @@ contract TestBaseContract is Test {
         IERC20 tkn = IERC20(token);
         tkn.approve(address(from), amount);
 
-        stdstore.target(token).sig(IERC20(token).balanceOf.selector).with_key(to).checked_write(amount);
+        stdstore.target(token).sig(IERC20(token).balanceOf.selector).with_key(to).checked_write(
+            amount
+        );
 
         assertEq(tkn.balanceOf(to), amount, "balance should INCREASE (after mint)");
     }
 
     address internal immutable account0 = address(this);
 
-    Wallet internal player1 = Wallet({ addr: vm.addr(1001), privateKey: 1001 });
-    Wallet internal player2 = Wallet({ addr: vm.addr(1002), privateKey: 1002 });
-    Wallet internal player3 = Wallet({ addr: vm.addr(1003), privateKey: 1003 });
-    Wallet internal player4 = Wallet({ addr: vm.addr(1004), privateKey: 1004 });
-    Wallet internal player5 = Wallet({ addr: vm.addr(1005), privateKey: 1005 });
+    Wallet[] internal players;
 
     Wallet internal server = Wallet({ addr: vm.addr(12345), privateKey: 12345 });
 
@@ -45,6 +43,8 @@ contract TestBaseContract is Test {
 
     address internal memeTokenAddress;
     IERC20 internal memeToken;
+
+    uint internal randomNonce;
 
     function setUp() public virtual {
         console2.log("account0", account0);
@@ -73,6 +73,11 @@ contract TestBaseContract is Test {
 
         // set ownership
         proxy.transferOwnership(account0);
+
+        // setup players
+        for (uint i = 0; i < 5; i++) {
+            players.push(Wallet({ addr: vm.addr(1001 + i), privateKey: 1001 + i }));
+        }
     }
 
     // ------------------------------------------------------ //
@@ -94,5 +99,13 @@ contract TestBaseContract is Test {
 
     function assertEq(BoutFighter a, BoutFighter b, string memory err) internal {
         assertEq(uint(a), uint(b), err);
+    }
+
+    function randUint() internal returns (uint256) {
+        randomNonce++;
+        // returns number between 0 and 99
+        return
+            uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty, randomNonce))) %
+            100;
     }
 }

--- a/test/utils/TestFacets.sol
+++ b/test/utils/TestFacets.sol
@@ -13,9 +13,9 @@ contract TestFacet1 {
         LibToken.mint(LibTokenIds.TOKEN_MEME, wallet, amount);
     }
 
-    function _testSetBoutState(uint boutNum, BoutState state) external {
+    function _testSetBoutState(uint boutId, BoutState state) external {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        s.bouts[boutNum].state = state;
+        s.bouts[boutId].state = state;
     }
 }
 

--- a/test/utils/TestFacets.sol
+++ b/test/utils/TestFacets.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.17 <0.9;
 import { IDiamondCut } from "lib/diamond-2-hardhat/contracts/interfaces/IDiamondCut.sol";
 
 import { AppStorage, LibAppStorage, BoutState } from "../../src/Objects.sol";
-import { LibConstants, LibTokenIds } from "../../src/libs/LibConstants.sol";
-import { LibToken } from "../../src/libs/LibToken.sol";
+import { LibConstants } from "../../src/libs/LibConstants.sol";
+import { LibToken, LibTokenIds } from "../../src/libs/LibToken.sol";
 import { InitDiamond } from "src/InitDiamond.sol";
 
 contract TestFacet1 {

--- a/test/utils/TestFacets.sol
+++ b/test/utils/TestFacets.sol
@@ -17,6 +17,16 @@ contract TestFacet1 {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.bouts[boutId].state = state;
     }
+
+    function _testGetUserWinningsToClaimListLength(address wallet) external returns (uint) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        return s.userBoutsWinningsToClaimList[wallet].len;
+    }
+
+    function _testSetBoutExpiryTime(uint boutId, uint expiryTime) external {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        s.bouts[boutId].expiryTime = expiryTime;
+    }
 }
 
 abstract contract ITestFacet is TestFacet1 {}
@@ -27,12 +37,22 @@ library LibTestFacetsHelper {
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
 
-        bytes4[] memory f1 = new bytes4[](2);
+        bytes4[] memory f1 = new bytes4[](4);
         f1[0] = TestFacet1._testMintMeme.selector;
         f1[1] = TestFacet1._testSetBoutState.selector;
-        cut[0] = IDiamondCut.FacetCut({ facetAddress: testFacet1, action: IDiamondCut.FacetCutAction.Add, functionSelectors: f1 });
+        f1[2] = TestFacet1._testGetUserWinningsToClaimListLength.selector;
+        f1[3] = TestFacet1._testSetBoutExpiryTime.selector;
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: testFacet1,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: f1
+        });
 
         InitDiamond initDiamond = new InitDiamond();
-        IDiamondCut(proxy).diamondCut(cut, address(initDiamond), abi.encodeCall(initDiamond.initialize, ()));
+        IDiamondCut(proxy).diamondCut(
+            cut,
+            address(initDiamond),
+            abi.encodeCall(initDiamond.initialize, ())
+        );
     }
 }


### PR DESCRIPTION
Further to the dev chat, this PR aims to simplify the flow to reduce the no. of calls the backend server has to make into the contract in order to orchestrate a bout. It also aims to make the system more resilient to server failures. We also want to allow players to bet on fights far into the future.

- [x] minimize no. of calls server has to make to contract - 1 call per bout
- [x] ensure winnings from prior bouts are claimed prior to transferring funds for a new bet
- [x] enable automatic bout timeout detection and reclaiming of bettors' funds - all fights will have a timeout
- [x] calling endBout() on timed out bout throws error
- [x] track player's unclaimed winnings bout list as a dynamic linked list so that we can easily skip over bouts that aren't yet ready to be processed
- [x] test: claimWinnings() called with max iterations set to 1 during bet()
- [x] test: auto-timeout when calling claimWinnings()

This changes will enable us to add `createBout()` later - to be callable by server to schedule a fight in advance, with custom timeout value - thus allowing players to place bets well in advance of bout
